### PR TITLE
Fix: [AEA-0000] - pin conventional-changelog-eslint to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@typescript-eslint/eslint-plugin": "^7.8.0",
         "@typescript-eslint/parser": "^7.8.0",
         "aws-lambda": "^1.0.7",
-        "conventional-changelog-eslint": "^6.0.0",
+        "conventional-changelog-eslint": "5.0.0",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-import-newlines": "^1.3.4",
@@ -5147,12 +5147,12 @@
       }
     },
     "node_modules/conventional-changelog-eslint": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-6.0.0.tgz",
-      "integrity": "sha512-eiUyULWjzq+ybPjXwU6NNRflApDWlPEQEHvI8UAItYW/h22RKkMnOAtfCZxMmrcMO1OKUWtcf2MxKYMWe9zJuw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-5.0.0.tgz",
+      "integrity": "sha512-6JtLWqAQIeJLn/OzUlYmzd9fKeNSWmQVim9kql+v4GrZwLx807kAJl3IJVc3jTYfVKWLxhC3BGUxYiuVEcVjgA==",
       "dev": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=16"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/NHSDigital/eps-prescription-status-update-api"
   },
-  "keywords": [ ],
+  "keywords": [],
   "author": "NHS Digital",
   "license": "MIT",
   "workspaces": [
@@ -29,7 +29,7 @@
     "@typescript-eslint/eslint-plugin": "^7.8.0",
     "@typescript-eslint/parser": "^7.8.0",
     "aws-lambda": "^1.0.7",
-    "conventional-changelog-eslint": "^6.0.0",
+    "conventional-changelog-eslint": "5.0.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import-newlines": "^1.3.4",


### PR DESCRIPTION
## Summary

- Routine Change

### Details

- pin conventional-changelog-eslint to 5.0.0 until https://github.com/conventional-changelog/conventional-changelog/issues/1269 is resolved