### PR TITLE
Fix: [AEA-4168] - 200 and 409 Response returned for the same Item

### DIFF
--- a/packages/updatePrescriptionStatus/src/updatePrescriptionStatus.ts
+++ b/packages/updatePrescriptionStatus/src/updatePrescriptionStatus.ts
@@ -69,14 +69,13 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
     return response(200, responseEntries)
   }
 
-  const entriesValid = validateEntries(requestEntries, responseEntries)
-  if (!entriesValid) {
-    return response(400, responseEntries)
-  }
-
-  const dataItems = buildDataItems(requestEntries, xRequestID, applicationName)
-
   try {
+    const entriesValid = validateEntries(requestEntries, responseEntries)
+    if (!entriesValid) {
+      return response(400, responseEntries)
+    }
+
+    const dataItems = buildDataItems(requestEntries, xRequestID, applicationName)
     const persistSuccess = persistDataItems(dataItems)
     const persistResponse = await jobWithTimeout(LAMBDA_TIMEOUT_MS, persistSuccess)
 


### PR DESCRIPTION
## Summary

https://nhsd-jira.digital.nhs.uk/browse/AEA-4168

2 Conflicting responses are returned for the same item if a 409 error is found due to a duplicate Task.ID. The expected 409 response is returned, however a 200 is returned with for the same Task.ID noting that the data is not committed.

- :sparkles: New Feature
