### PR TITLE
Fix: [AEA-4167] - Unable to find lowercase item ids

### DIFF
--- a/packages/gsul/src/dynamoDBclient.ts
+++ b/packages/gsul/src/dynamoDBclient.ts
@@ -33,15 +33,8 @@ export async function getItemsUpdatesForPrescription(
     return rows
   }
 
-  const items = await getAllData({
-    TableName: tableName,
-    IndexName: "PharmacyODSCodePrescriptionIDIndex",
-    KeyConditionExpression: "PrescriptionID = :inputPrescriptionID AND PharmacyODSCode = :inputPharmacyODSCode",
-    ExpressionAttributeValues: {
-      ":inputPharmacyODSCode": odsCode,
-      ":inputPrescriptionID": prescriptionID
-    }
-  })
+  const queryCommandInput = createQueryCommandInput(odsCode, prescriptionID)
+  const items = await getAllData(queryCommandInput)
 
   return items.map((singleUpdate) => ({
     itemId: String(singleUpdate.LineItemID),
@@ -49,4 +42,16 @@ export async function getItemsUpdatesForPrescription(
     isTerminalState: String(singleUpdate.TerminalStatus),
     lastUpdateDateTime: String(singleUpdate.LastModified)
   }))
+}
+
+export function createQueryCommandInput(odsCode: string, prescriptionID: string): QueryCommandInput {
+  return {
+    TableName: tableName,
+    IndexName: "PharmacyODSCodePrescriptionIDIndex",
+    KeyConditionExpression: "PrescriptionID = :inputPrescriptionID AND PharmacyODSCode = :inputPharmacyODSCode",
+    ExpressionAttributeValues: {
+      ":inputPharmacyODSCode": odsCode.toUpperCase(),
+      ":inputPrescriptionID": prescriptionID.toUpperCase()
+    }
+  }
 }

--- a/packages/gsul/tests/testRunDynamoDBQueries.test.ts
+++ b/packages/gsul/tests/testRunDynamoDBQueries.test.ts
@@ -1,5 +1,5 @@
 import {DynamoDBDocumentClient} from "@aws-sdk/lib-dynamodb"
-import {getItemsUpdatesForPrescription} from "../src/dynamoDBclient"
+import {createQueryCommandInput, getItemsUpdatesForPrescription} from "../src/dynamoDBclient"
 import {Logger} from "@aws-lambda-powertools/logger"
 import {
   expect,
@@ -41,6 +41,22 @@ describe("testing dynamoDBClient", () => {
         lastUpdateDateTime: "1970-01-01T00:00:00Z"
       }
     ])
+  })
+
+  it("should create query command input with keys in upper case", async () => {
+    const queryCommandInput = createQueryCommandInput("odsCode", "prescriptionID")
+
+    const expected = {
+      TableName: undefined,
+      IndexName: "PharmacyODSCodePrescriptionIDIndex",
+      KeyConditionExpression: "PrescriptionID = :inputPrescriptionID AND PharmacyODSCode = :inputPharmacyODSCode",
+      ExpressionAttributeValues: {
+        ":inputPharmacyODSCode": "ODSCODE",
+        ":inputPrescriptionID": "PRESCRIPTIONID"
+      }
+    }
+
+    expect(queryCommandInput).toEqual(expected)
   })
 })
 

--- a/packages/updatePrescriptionStatus/src/updatePrescriptionStatus.ts
+++ b/packages/updatePrescriptionStatus/src/updatePrescriptionStatus.ts
@@ -195,10 +195,10 @@ export function buildDataItems(
 
     const dataItem: DataItem = {
       LastModified: task.lastModified!,
-      LineItemID: task.focus!.identifier!.value!,
+      LineItemID: task.focus!.identifier!.value!.toUpperCase(),
       PatientNHSNumber: task.for!.identifier!.value!,
       PharmacyODSCode: task.owner!.identifier!.value!,
-      PrescriptionID: task.basedOn![0].identifier!.value!,
+      PrescriptionID: task.basedOn![0].identifier!.value!.toUpperCase(),
       RequestID: xRequestID,
       Status: task.businessStatus!.coding![0].code!,
       TaskID: task.id!,

--- a/packages/updatePrescriptionStatus/src/updatePrescriptionStatus.ts
+++ b/packages/updatePrescriptionStatus/src/updatePrescriptionStatus.ts
@@ -197,7 +197,7 @@ export function buildDataItems(
       LastModified: task.lastModified!,
       LineItemID: task.focus!.identifier!.value!.toUpperCase(),
       PatientNHSNumber: task.for!.identifier!.value!,
-      PharmacyODSCode: task.owner!.identifier!.value!,
+      PharmacyODSCode: task.owner!.identifier!.value!.toUpperCase(),
       PrescriptionID: task.basedOn![0].identifier!.value!.toUpperCase(),
       RequestID: xRequestID,
       Status: task.businessStatus!.coding![0].code!,

--- a/packages/updatePrescriptionStatus/tests/testUpdatePrescriptionStatus.test.ts
+++ b/packages/updatePrescriptionStatus/tests/testUpdatePrescriptionStatus.test.ts
@@ -208,12 +208,14 @@ describe("handleTransactionCancelledException", () => {
 })
 
 describe("buildDataItems", () => {
-  it("should uppercase LineItemId and PrescriptionID", () => {
+  it("should uppercase LineItemId, PharmacyODSCode and PrescriptionID", () => {
     const task = validTask()
     const lineItemID = v4().toUpperCase()
+    const pharmacyODSCode = "X26"
     const prescriptionID = "4F00A8-A83008-2EB4D"
 
     task.focus!.identifier!.value! = lineItemID.toLowerCase()
+    task.owner!.identifier!.value! = pharmacyODSCode.toLowerCase()
     task.basedOn![0].identifier!.value! = prescriptionID.toLowerCase()
     const requestEntry: BundleEntry = {
       resource: task,
@@ -224,5 +226,6 @@ describe("buildDataItems", () => {
 
     expect(dataItems[0].LineItemID).toEqual(lineItemID)
     expect(dataItems[0].PrescriptionID).toEqual(prescriptionID)
+    expect(dataItems[0].PharmacyODSCode).toEqual(pharmacyODSCode)
   })
 })

--- a/packages/updatePrescriptionStatus/tests/testUpdatePrescriptionStatus.test.ts
+++ b/packages/updatePrescriptionStatus/tests/testUpdatePrescriptionStatus.test.ts
@@ -7,17 +7,22 @@ import {
 } from "@jest/globals"
 
 import {BundleEntry} from "fhir/r4"
+import {v4} from "uuid"
 
 import {badRequest, conflictDuplicate} from "../src/utils/responses"
-import {DEFAULT_DATE, X_REQUEST_ID, mockInternalDependency} from "./utils/testUtils"
+import {
+  DEFAULT_DATE,
+  X_REQUEST_ID,
+  mockInternalDependency,
+  validTask
+} from "./utils/testUtils"
 import {APIGatewayProxyEvent} from "aws-lambda"
 
 import * as content from "../src/validation/content"
 import {TransactionCanceledException} from "@aws-sdk/client-dynamodb"
 const mockValidateEntry = mockInternalDependency("../src/validation/content", content, "validateEntry")
-const {castEventBody, getXRequestID, validateEntries, handleTransactionCancelledException} = await import(
-  "../src/updatePrescriptionStatus"
-)
+const {castEventBody, getXRequestID, validateEntries, handleTransactionCancelledException, buildDataItems} =
+  await import("../src/updatePrescriptionStatus")
 
 describe("Unit test getXRequestID", () => {
   beforeAll(() => {
@@ -199,5 +204,25 @@ describe("handleTransactionCancelledException", () => {
     expect(validResponseEntry).toEqual(conflictDuplicate("d70678c-81e4-6665-8c67-17596fd0aa87"))
     expect(validResponseEntry.response?.status).toEqual("409 Conflict")
     expect(validResponseEntry.response?.status).not.toEqual("200 OK")
+  })
+})
+
+describe("buildDataItems", () => {
+  it("should uppercase LineItemId and PrescriptionID", () => {
+    const task = validTask()
+    const lineItemID = v4().toUpperCase()
+    const prescriptionID = "4F00A8-A83008-2EB4D"
+
+    task.focus!.identifier!.value! = lineItemID.toLowerCase()
+    task.basedOn![0].identifier!.value! = prescriptionID.toLowerCase()
+    const requestEntry: BundleEntry = {
+      resource: task,
+      fullUrl: ""
+    }
+
+    const dataItems = buildDataItems([requestEntry], "", "")
+
+    expect(dataItems[0].LineItemID).toEqual(lineItemID)
+    expect(dataItems[0].PrescriptionID).toEqual(prescriptionID)
   })
 })


### PR DESCRIPTION
## Summary

- Routine Change

### Details

Converting potentially case-sensitive keys to uppercase when accepting and returning status updates.