### PR TITLE
Update: [AEA-4169] - Translate Cegedim collected statuses delivered by robot to dispatched

### DIFF
--- a/packages/cpsuLambda/src/schema/format_1/transformer.ts
+++ b/packages/cpsuLambda/src/schema/format_1/transformer.ts
@@ -99,7 +99,16 @@ function populateTemplate(
     )
     return Err(`Invalid business status on item ${prescriptionItem.itemID}`)
   } else {
-    entry.resource!.businessStatus!.coding![0].code = businessStatus.value()
+    const statusValue = businessStatus.value()
+    entry.resource!.businessStatus!.coding![0].code = statusValue
+
+    if (prescriptionDetails.deliveryType === "Robot Collection") {
+      if (prescriptionItem.status === "ReadyForCollection") {
+        entry.resource!.status = "in-progress"
+      } else if (prescriptionItem.status === "DispensingComplete") {
+        entry.resource!.status = "completed"
+      }
+    }
   }
 
   entry.resource!.focus!.identifier!.value = prescriptionItem.itemID
@@ -168,13 +177,13 @@ const BUSINESS_STATUS_MAP: ItemStatusMap = {
   NotDispensed: "Not Dispensed",
   ReadyForCollection: {
     "In-Store Collection": "Ready to Collect",
-    "Robot Collection": "Ready to Collect",
+    "Robot Collection": "Ready to Dispatch",
     "Delivery required": "Ready to Dispatch"
   },
   PartOwed: "With Pharmacy - Preparing Remainder",
   DispensingComplete: {
     "In-Store Collection": "Collected",
-    "Robot Collection": "Collected",
+    "Robot Collection": "Dispatched",
     "Delivery required": "Dispatched"
   }
 }

--- a/packages/cpsuLambda/tests/format_1/business_states.test.ts
+++ b/packages/cpsuLambda/tests/format_1/business_states.test.ts
@@ -6,7 +6,7 @@ it("should convert a delivery type business status", () => {
   const deliveryType: deliveryType = "Robot Collection"
 
   const businessStatus = getBusinessStatus(deliveryType, itemStatus)
-  expect(businessStatus.value()).toEqual("Ready to Collect")
+  expect(businessStatus.value()).toEqual("Ready to Dispatch")
 })
 
 it("should convert an item status business status", () => {
@@ -23,4 +23,36 @@ it("should return Nothing if the item status is not in the map", () => {
 
   const businessStatus = getBusinessStatus(deliveryType, itemStatus)
   expect(businessStatus.isNothing()).toBeTruthy()
+})
+
+it("should convert a DispensingComplete status with Robot Collection", () => {
+  const itemStatus: itemStatusType = "DispensingComplete"
+  const deliveryType: deliveryType = "Robot Collection"
+
+  const businessStatus = getBusinessStatus(deliveryType, itemStatus)
+  expect(businessStatus.value()).toEqual("Dispatched")
+})
+
+it("should handle ReadyForCollection status with Robot Collection correctly", () => {
+  const itemStatus: itemStatusType = "ReadyForCollection"
+  const deliveryType: deliveryType = "Robot Collection"
+
+  const businessStatus = getBusinessStatus(deliveryType, itemStatus)
+  expect(businessStatus.value()).toEqual("Ready to Dispatch")
+})
+
+it("should convert a delivery type business status for Delivery required", () => {
+  const itemStatus: itemStatusType = "ReadyForCollection"
+  const deliveryType: deliveryType = "Delivery required"
+
+  const businessStatus = getBusinessStatus(deliveryType, itemStatus)
+  expect(businessStatus.value()).toEqual("Ready to Dispatch")
+})
+
+it("should convert an item status business status for Delivery required", () => {
+  const itemStatus: itemStatusType = "DispensingComplete"
+  const deliveryType: deliveryType = "Delivery required"
+
+  const businessStatus = getBusinessStatus(deliveryType, itemStatus)
+  expect(businessStatus.value()).toEqual("Dispatched")
 })


### PR DESCRIPTION
## Summary

🎫 [AEA-4169](https://nhsd-jira.digital.nhs.uk/browse/AEA-4169) Translate Cegedim collected statuses delivered by robot to dispatched

- Routine Change

### Details

Acceptance Criteria:
1. The solution must translate a Cegedim Rx status update where Status =  Ready to Collect AND deliveryType = Robot Collection to Status = Ready to dispatch AND Terminal Status = In-progress before storing the update in the data store
2. The solution must translate a Cegedim Rx status update where Status =  DispensingComplete AND deliveryType = Robot Collection to Status = Dispatched AND Terminal Status = Completed before storing the update in the data store