### PR TITLE
Fix: [AEA-0000] - change esbuild to bundle dependendencies

### DIFF
--- a/SAMtemplates/functions/main.yaml
+++ b/SAMtemplates/functions/main.yaml
@@ -59,6 +59,7 @@ Resources:
         Target: es2020
         Sourcemap: true
         tsconfig: updatePrescriptionStatus/tsconfig.json
+        packages: bundle
         EntryPoints:
           - updatePrescriptionStatus/src/updatePrescriptionStatus.ts
 
@@ -97,6 +98,7 @@ Resources:
         Target: es2020
         Sourcemap: true
         tsconfig: cpsuLambda/tsconfig.json
+        packages: bundle
         EntryPoints:
           - cpsuLambda/src/cpsu.ts
 
@@ -133,6 +135,7 @@ Resources:
         Target: es2020
         Sourcemap: true
         tsconfig: gsul/tsconfig.json
+        packages: bundle
         EntryPoints:
           - gsul/src/getStatusUpdates.ts
 
@@ -172,6 +175,7 @@ Resources:
         Target: es2020
         Sourcemap: true
         tsconfig: statusLambda/tsconfig.json
+        packages: bundle
         EntryPoints:
           - statusLambda/src/statusLambda.ts
 
@@ -207,6 +211,7 @@ Resources:
         Target: es2020
         Sourcemap: true
         tsconfig: capabilityStatement/tsconfig.json
+        packages: bundle
         EntryPoints:
           - capabilityStatement/src/capabilityStatement.ts
 


### PR DESCRIPTION
## Summary

- Routine Change

### Details

- change esbuild to bundle dependencies following default behavior in esbuild 0.22 - https://github.com/evanw/esbuild/releases/tag/v0.22.0