### PR TITLE
Docs: [AEA-4192] - Adding missing sections to CPSU spec

### DIFF
--- a/packages/specification/eps-custom-prescription-status-update-api.yaml
+++ b/packages/specification/eps-custom-prescription-status-update-api.yaml
@@ -10,6 +10,62 @@ info:
     name: Custom Prescription Status Update API Support
     url: https://digital.nhs.uk/developer/help-and-support
     email: api.management@nhs.net
+  description: |
+    ## Overview
+    The Custom Prescription Status Update API is restricted to dispensing suppliers with an existing prescription 
+    status update solution, who can onboard to provide updates to patients on a national scale via the NHS App 
+    (and other third parties in the future) by September 2024.
+    ## Who can use this API
+    The Custom Prescription Status Update API is intended for those dispensing suppliers who have signed the MOU to 
+    supply status updates by September 2024, so they can provide and push the information required to a central NHS data store.
+    ## Related APIs
+    The following APIs are related to the "Custom Prescription Status Update" API:
+    * [Electronic Prescriptions Service](https://digital.nhs.uk/developer/api-catalogue/electronic-prescription-service-fhir): the national service for creating and dispensing prescriptions across health and social care.
+    * [Prescriptions for Patients](https://digital.nhs.uk/developer/api-catalogue/prescriptions-for-patients): the national service to retrieve prescriptions data for individual patients from the Electronic Prescription Service (EPS), for use in patient-facing applications.
+    ## API Status and Roadmap
+    This API is [in development](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#statuses), meaning the API will soon be available for testing via a sandbox service or an integration environment - but we expect to make breaking changes based on developer feedback.
+    ## Service Level
+    This API is a platinum service, meaning it is operational and supported 24 hours a day, 365 days a year.
+    For more details see [service levels](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#service-levels).
+    ## Technology
+    This API is [RESTful](https://digital.nhs.uk/developer/guides-and-documentation/our-api-technologies#basic-rest).
+    ## Network Access
+    This API is available on the internet.
+    For more details see [Network access for APIs](https://digital.nhs.uk/developer/guides-and-documentation/network-access-for-apis).
+    ## Security and Authorisation
+    This API only supports [application-restricted access](https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation/application-restricted-restful-apis-api-key-authentication), meaning we authenticate the calling application but not the end user.
+    ### Application-restricted Access
+    The end user could be:
+    * a healthcare worker - in which case you must ensure they are authenticated and suitably authorised locally
+    * not present at all - for example as part of a back end process to check NHS numbers for data flowing from one system to another
+    ### Errors
+    We use standard HTTP status codes to show whether an API request succeeded or not.
+    They are usually in the range:
+    * 200 to 299 if it succeeded, including code 202 if it was accepted by an API that needs to wait for further action
+    * 400 to 499 if it failed because of a client error by your application
+    * 500 to 599 if it failed because of an error on our server
+    Errors specific to each API are shown in the Endpoints section, under Response. See our [reference guide](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#http-status-codes) for more on errors.
+    ## Environment and testing
+    | Environment      | Base URL                                                            |
+    |------------------|---------------------------------------------------------------------|
+    | Sandbox          | `https://sandbox.api.service.nhs.uk/custom-prescription-status-update`     |
+    | Integration test | `https://int.api.service.nhs.uk/custom-prescription-status-update`         |
+    | Production       | `https://api.service.nhs.uk/custom-prescription-status-update`             |
+    ### Sandbox testing
+    Our [sandbox environment](https://digital.nhs.uk/developer/guides-and-documentation/testing#sandbox-testing):
+    * is for early developer testing
+    * only covers a limited set of scenarios
+    * is stateless, so it does not actually persist any updates
+    * is open access, so does not allow you to test authorisation
+    For details of sandbox testing, or to try out the sandbox using our "Try this API" feature, see the documentation for each endpoint.
+    ### Integration testing
+    Our [integration test environment](https://digital.nhs.uk/developer/guides-and-documentation/testing#integration-testing):
+    * is for formal integration testing
+    * is stateful, so persists updates
+    * includes authorisation, with [smartcard](https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation/nhs-smartcards-for-developers) and non-smartcard options
+    For more details see [integration testing with our RESTful APIs](https://digital.nhs.uk/developer/guides-and-documentation/testing#integration-testing-with-our-restful-apis).
+    ## Onboarding
+    All dispenser suppliers are being asked to integrate with this new service.
 
 servers:
   - url: "https://int.api.service.nhs.uk/custom-prescription-status-update"


### PR DESCRIPTION
## Summary
Routine Change

Added the standard sections to the CPSU spec, used the PSU spec as a base with the alterations mentioned in the ACs of the ticket .
