### PR TITLE
Build: [AEA-0000] - Add missing parameter to sam-sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ sam-deploy: guard-AWS_DEFAULT_PROFILE guard-stack_name
 	sam deploy \
 		--stack-name $$stack_name \
 		--parameter-overrides \
-			  EnableSplunk=false
+			  EnableSplunk=false \
+			  DeployCheckPrescriptionStatusUpdate=true 
 
 sam-delete: guard-AWS_DEFAULT_PROFILE guard-stack_name
 	sam delete --stack-name $$stack_name


### PR DESCRIPTION
## Summary

- :robot: Operational or Infrastructure Change

### Details

The `make sam-sync` command was failing, as the `DeployCheckPrescriptionStatusUpdate` was unset. I've simply hardcoded this to `true`'

This is a duplicate of PR #516 - I'd not made signed commits. This PR should be properly signed!