### PR TITLE
Update: [AEA-4237] - Translate a 409 response code in the CPSU to 202 response code

### DIFF
--- a/SAMtemplates/state_machines/Format1UpdatePrescriptionsStatusStateMachine.asl.json
+++ b/SAMtemplates/state_machines/Format1UpdatePrescriptionsStatusStateMachine.asl.json
@@ -85,7 +85,7 @@
             "Content-Type": "application/fhir+json",
             "Cache-Control": "no-cache"
           },
-          "body": "{\"resourceType\":\"OperationOutcome\",\"issue\":[{\"severity\":\"information\",\"code\":\"information\",\"diagnostics\":\"Duplicate update detected. The message was valid but did not result in an update.\"}]}"
+          "body": "{\"resourceType\":\"OperationOutcome\",\"issue\":[{\"severity\":\"information\",\"code\":\"informational\",\"diagnostics\":\"Duplicate update detected. The message was valid but did not result in an update.\"}]}"
         }
       },
       "End": true

--- a/SAMtemplates/state_machines/Format1UpdatePrescriptionsStatusStateMachine.asl.json
+++ b/SAMtemplates/state_machines/Format1UpdatePrescriptionsStatusStateMachine.asl.json
@@ -51,7 +51,7 @@
         "Payload.$": "$",
         "FunctionName": "${UpdatePrescriptionStatusFunctionArn}"
       },
-      "End": true,
+      "Next": "Check Update Prescription Status Result",
       "Catch": [
         {
           "ErrorEquals": [
@@ -64,6 +64,35 @@
         "Payload.$": "$.Payload"
       },
       "InputPath": "$.Payload "
+    },
+    "Check Update Prescription Status Result": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.Payload.statusCode",
+          "NumericEquals": 409,
+          "Next": "Translate 409 to 202"
+        }
+      ],
+      "Default": "End State"
+    },
+    "Translate 409 to 202": {
+      "Type": "Pass",
+      "Result": {
+        "Payload": {
+          "statusCode": 202,
+          "headers": {
+            "Content-Type": "application/fhir+json",
+            "Cache-Control": "no-cache"
+          },
+          "body": "{\"resourceType\":\"OperationOutcome\",\"issue\":[{\"severity\":\"information\",\"code\":\"information\",\"diagnostics\":\"Duplicate update detected. The message was valid but did not result in an update.\"}]}"
+        }
+      },
+      "End": true
+    },
+    "End State": {
+      "Type": "Pass",
+      "End": true
     },
     "CatchAllError": {
       "Type": "Pass",

--- a/packages/cpsuLambda/tests/testHandler.test.ts
+++ b/packages/cpsuLambda/tests/testHandler.test.ts
@@ -25,7 +25,7 @@ const TEST_HEADERS = {
   "x-correlation-id": "test-x-correlation-id",
   "attribute-name": "test-attribute-value"
 }
-// Add a test for translate a 409 response code to 202 response code
+
 describe("generic handler", () => {
   test("Headers are appended to logger", async () => {
     const event = {

--- a/packages/cpsuLambda/tests/testHandler.test.ts
+++ b/packages/cpsuLambda/tests/testHandler.test.ts
@@ -25,7 +25,7 @@ const TEST_HEADERS = {
   "x-correlation-id": "test-x-correlation-id",
   "attribute-name": "test-attribute-value"
 }
-
+// Add a test for translate a 409 response code to 202 response code
 describe("generic handler", () => {
   test("Headers are appended to logger", async () => {
     const event = {


### PR DESCRIPTION
## Summary

🎫 [AEA-4237](https://nhsd-jira.digital.nhs.uk/browse/AEA-4237) Translate a 409 response code in the CPSU to 202 response code

- Routine Change

### Details

The solution must translate a 409 code in the response from a status update submitted by the Cegedim application to a 202 code before sending the API response.