### PR TITLE
Fix: [AEA-4256] - Scottish and NI NHS numbers not being rejected

### DIFF
--- a/packages/updatePrescriptionStatus/src/validation/content.ts
+++ b/packages/updatePrescriptionStatus/src/validation/content.ts
@@ -80,7 +80,8 @@ export function nhsNumberRange(task: Task): string | undefined {
   const validRanges: Array<Range> = [
     {low: 3_113_000_000, high: 3_200_000_000},
     {low: 4_000_000_000, high: 4_999_999_999},
-    {low: 6_000_000_000, high: 7_999_999_999}
+    {low: 6_000_000_000, high: 7_999_999_999},
+    {low: 9_000_000_000, high: 9_999_999_999}
   ]
 
   const nhsNumber = Number(task.for!.identifier!.value)
@@ -167,6 +168,7 @@ export function taskContent(task: Task): Array<string> {
     businessStatus,
     lastModified,
     nhsNumber,
+    nhsNumberRange,
     prescriptionID,
     resourceType,
     taskStatusAgainstBusinessStatus,

--- a/packages/updatePrescriptionStatus/tests/validation/testRequestContentValidation.test.ts
+++ b/packages/updatePrescriptionStatus/tests/validation/testRequestContentValidation.test.ts
@@ -62,7 +62,10 @@ describe("Unit test for validateContent", () => {
     task.focus!.identifier!.system = "invalidLineItemIdCodeSystem"
     const entry: BundleEntry = {fullUrl: FULL_URL_0, resource: task}
 
-    const expectedOutcome = {valid: false, issues: "NHS number is invalid. Invalid CodeSystem(s) - LineItemID."}
+    const expectedOutcome = {
+      valid: false,
+      issues: "NHS number is invalid. NHS number is not in a known, valid range. Invalid CodeSystem(s) - LineItemID."
+    }
 
     const actual: ValidationOutcome = validateContent(entry)
 
@@ -83,7 +86,11 @@ describe("Unit test for taskContent", () => {
     task.for!.identifier!.value = "invalidNhsNumber"
     task.focus!.identifier!.system = "invalidLineItemIdCodeSystem"
 
-    const expectedOutcome = ["NHS number is invalid.", "Invalid CodeSystem(s) - LineItemID."]
+    const expectedOutcome = [
+      "NHS number is invalid.",
+      "NHS number is not in a known, valid range.",
+      "Invalid CodeSystem(s) - LineItemID."
+    ]
 
     const actual: Array<string> = taskContent(task)
 
@@ -224,7 +231,16 @@ describe("Unit tests for validation of NHS number range", () => {
       scenarioDescription: "When NHS number is in the Northern Irish range, should return expected issue."
     },
     {
-      nhsNumbers: ["3113000000", "3200000000", "4000000000", "4999999999", "6000000000", "7999999999"],
+      nhsNumbers: [
+        "3113000000",
+        "3200000000",
+        "4000000000",
+        "4999999999",
+        "6000000000",
+        "7999999999",
+        "9000000000",
+        "9999999999"
+      ],
       expected: undefined,
       scenarioDescription: "When NHS number is in the NHSE range."
     }


### PR DESCRIPTION
## Summary

- Routine Change

### Details

Fix for a bug where the additional validation wasn't included in the list of validations being applied. Addition of range for test NHS numbers.