### PR TITLE
Fix: [AEA-4287] - x-request-id not added to cpsu logs

### DIFF
--- a/packages/cpsuLambda/src/handler.ts
+++ b/packages/cpsuLambda/src/handler.ts
@@ -46,26 +46,24 @@ async function generic_handler<Event extends EventWithHeaders, Message>(
 }
 
 function append_headers(headers: Record<string, string>, logger: Logger) {
-  logger.info("in append_headers", {headers})
   const headers_to_append: Record<string, string> = {}
   if (headers["apigw-request-id"]) {
-    logger.info("adding apigw-request-id")
     headers_to_append["apigw-request-id"] = headers["apigw-request-id"]
   }
   if (headers["nhsd-correlation-id"]) {
-    logger.info("nhsd-correlation-id")
     headers_to_append["nhsd-correlation-id"] = headers["nhsd-correlation-id"]
   }
   if (headers["nhsd-request-id"]) {
-    logger.info("adding nhsd-request-id")
     headers_to_append["nhsd-request-id"] = headers["nhsd-request-id"]
   }
   if (headers["x-correlation-id"]) {
-    logger.info("adding x-correlation-id")
     headers_to_append["x-correlation-id"] = headers["x-correlation-id"]
   }
-  logger.info("headers_to_append", {headers_to_append})
+  if (headers["x-request-id"]) {
+    headers_to_append["x-request-id"] = headers["x-request-id"]
+  }
   logger.appendKeys(headers_to_append)
+  logger.info("added headers to logger for tracing", {headers_to_append})
 }
 
 /**

--- a/packages/cpsuLambda/src/handler.ts
+++ b/packages/cpsuLambda/src/handler.ts
@@ -46,19 +46,25 @@ async function generic_handler<Event extends EventWithHeaders, Message>(
 }
 
 function append_headers(headers: Record<string, string>, logger: Logger) {
+  logger.info("in append_headers", {headers})
   const headers_to_append: Record<string, string> = {}
   if (headers["apigw-request-id"]) {
+    logger.info("adding apigw-request-id")
     headers_to_append["apigw-request-id"] = headers["apigw-request-id"]
   }
   if (headers["nhsd-correlation-id"]) {
+    logger.info("nhsd-correlation-id")
     headers_to_append["nhsd-correlation-id"] = headers["nhsd-correlation-id"]
   }
   if (headers["nhsd-request-id"]) {
+    logger.info("adding nhsd-request-id")
     headers_to_append["nhsd-request-id"] = headers["nhsd-request-id"]
   }
   if (headers["x-correlation-id"]) {
+    logger.info("adding x-correlation-id")
     headers_to_append["x-correlation-id"] = headers["x-correlation-id"]
   }
+  logger.info("headers_to_append", {headers_to_append})
   logger.appendKeys(headers_to_append)
 }
 

--- a/packages/cpsuLambda/tests/testHandler.test.ts
+++ b/packages/cpsuLambda/tests/testHandler.test.ts
@@ -27,7 +27,7 @@ const TEST_HEADERS = {
 }
 
 describe("generic handler", () => {
-  test("Headers are appended to logger", async () => {
+  test.skip("Headers are appended to logger", async () => {
     const event = {
       headers: {
         "apigw-request-id": "test-apigw-request-id",

--- a/packages/cpsuLambda/tests/testHandler.test.ts
+++ b/packages/cpsuLambda/tests/testHandler.test.ts
@@ -27,13 +27,14 @@ const TEST_HEADERS = {
 }
 
 describe("generic handler", () => {
-  test.skip("Headers are appended to logger", async () => {
+  test("Headers are appended to logger", async () => {
     const event = {
       headers: {
         "apigw-request-id": "test-apigw-request-id",
         "nhsd-correlation-id": "test-nhsd-correlation-id",
         "nhsd-request-id": "test-nhsd-request-id",
-        "x-correlation-id": "test-x-correlation-id"
+        "x-correlation-id": "test-x-correlation-id",
+        "x-request-id": "test-x-request-id"
       }
     }
 
@@ -62,6 +63,7 @@ describe("generic handler", () => {
     expect(logger_call["nhsd-correlation-id"]).toEqual("test-nhsd-correlation-id")
     expect(logger_call["nhsd-request-id"]).toEqual("test-nhsd-request-id")
     expect(logger_call["x-correlation-id"]).toEqual("test-x-correlation-id")
+    expect(logger_call["x-request-id"]).toEqual("test-x-request-id")
   })
 })
 


### PR DESCRIPTION
## Summary

- Routine Change

### Details

- add x-request-id to cpsu logs
- log a message after adding headers to ensure that something is logged