### PR TITLE
New: [AEA-5199] - Setup notifications flow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,6 +86,16 @@ repos:
         files: ^packages\/checkPrescriptionStatusUpdates
         types_or: [ts, tsx, javascript, jsx, json]
         pass_filenames: false
+        
+      - id: lint-nhsNotifyLambda
+        name: Lint nhsNotifyLambda
+        entry: npm
+        args:
+          ["run", "--prefix=packages/nhsNotifyLambda", "lint"]
+        language: system
+        files: ^packages\/nhsNotifyLambda
+        types_or: [ts, tsx, javascript, jsx, json]
+        pass_filenames: false
 
       - id: lint-commonTesting
         name: Lint common/testing

--- a/.vscode/eps-prescription-status-update-api.code-workspace
+++ b/.vscode/eps-prescription-status-update-api.code-workspace
@@ -29,6 +29,10 @@
       "path": "../packages/cpsuLambda"
     },
     {
+      "name": "packages/nhsNotifyLambda",
+      "path": "../packages/nhsNotifyLambda"
+    },
+    {
       "name": "packages/capabilityStatement",
       "path": "../packages/capabilityStatement"
     },

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ lint-node: compile-node
 	npm run lint --workspace packages/capabilityStatement
 	npm run lint --workspace packages/cpsuLambda
 	npm run lint --workspace packages/checkPrescriptionStatusUpdates
+	npm run lint --workspace packages/nhsNotifyLambda
 	npm run lint --workspace packages/common/testing
 	npm run lint --workspace packages/common/middyErrorHandler
 
@@ -144,6 +145,7 @@ test: compile
 	npm run test --workspace packages/capabilityStatement
 	npm run test --workspace packages/cpsuLambda
 	npm run test --workspace packages/checkPrescriptionStatusUpdates
+	npm run test --workspace packages/nhsNotifyLambda
 	npm run test --workspace packages/common/middyErrorHandler
 
 clean:
@@ -159,6 +161,8 @@ clean:
 	rm -rf packages/capabilityStatement/lib
 	rm -rf packages/cpsuLambda/coverage
 	rm -rf packages/cpsuLambda/lib
+	rm -rf packages/nhsNotifyLambda/coverage
+	rm -rf packages/nhsNotifyLambda/lib
 	rm -rf packages/checkPrescriptionStatusUpdates/lib
 	rm -rf packages/common/testing/lib
 	rm -rf packages/common/middyErrorHandler/lib

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This is the AWS layer that provides an API for EPS Prescription Status Update.
 - `packages/statusLambda/` Returns the status of the updatePrescriptionStatus endpoint
 - `packages/capabilityStatement/` Returns a static capability statement.
 - `packages/cpsuLambda` Handles updating prescription status using a custom format.
+- `packages/nhsNotifyLambda` Handles sending prescription notifications to the NHS notify service.
 - `scripts/` Utilities helpful to developers of this specification.
 - `postman/` Postman collections to call the APIs. Documentation on how to use them are in the collections.
 - `SAMtemplates/` Contains the SAM templates used to define the stacks.

--- a/SAMtemplates/event_bridge/main.yaml
+++ b/SAMtemplates/event_bridge/main.yaml
@@ -1,0 +1,38 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  Scheduler to trigger NHSNotifyLambda every minute
+
+Parameters:
+  StackName:
+    Type: String
+  NHSNotifyLambdaArn:
+    Type: String
+    Description: The ARN of the NHSNotifyLambda function
+
+Resources:
+  NHSNotifyScheduler:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: !Sub "${StackName}-NHSNotifySchedulerRule"
+      ScheduleExpression: "rate(1 minute)"
+      State: ENABLED
+      Targets:
+        - Arn: !Ref NHSNotifyLambdaArn
+          Id: "NHSNotifyLambdaTarget"
+
+  NHSNotifyLambdaInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref NHSNotifyLambdaArn
+      Action: "lambda:InvokeFunction"
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt NHSNotifyScheduler.Arn
+
+Outputs:
+  SchedulerRuleName:
+    Description: Name of the scheduler rule triggering NHSNotifyLambda
+    Value: !Ref NHSNotifyScheduler
+  SchedulerRuleArn:
+    Description: ARN of the scheduler rule triggering NHSNotifyLambda
+    Value: !GetAtt NHSNotifyScheduler.Arn

--- a/SAMtemplates/functions/main.yaml
+++ b/SAMtemplates/functions/main.yaml
@@ -320,6 +320,47 @@ Resources:
         SplunkSubscriptionFilterRole: !ImportValue lambda-resources:SplunkSubscriptionFilterRole
         SplunkDeliveryStreamArn: !ImportValue lambda-resources:SplunkDeliveryStream
 
+  NHSNotifyLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub ${StackName}-NHSNotifyLambda
+      CodeUri: ../../packages
+      Handler: nhsNotifyLambda.lambdaHandler
+      Role: !GetAtt NHSNotifyLambdaResources.Outputs.LambdaRoleArn
+      Environment:
+        Variables:
+          LOG_LEVEL: !Ref LogLevel
+    Metadata:
+      BuildMethod: esbuild
+      guard:
+        SuppressedRules:
+          - LAMBDA_DLQ_CHECK
+          - LAMBDA_INSIDE_VPC
+          - LAMBDA_CONCURRENCY_CHECK
+      BuildProperties:
+        Minify: true
+        Target: es2020
+        Sourcemap: true
+        tsconfig: nhsNotifyLambda/tsconfig.json
+        packages: bundle
+        EntryPoints:
+          - nhsNotifyLambda/src/nhsNotifyLambda.ts
+
+  NHSNotifyLambdaResources:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: lambda_resources.yaml
+      Parameters:
+        StackName: !Ref StackName
+        LambdaName: !Sub ${StackName}-NHSNotifyLambda
+        LambdaArn: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${StackName}-NHSNotifyLambda
+        IncludeAdditionalPolicies: false
+        LogRetentionInDays: !Ref LogRetentionInDays
+        CloudWatchKMSKeyId: !ImportValue account-resources:CloudwatchLogsKmsKeyArn
+        EnableSplunk: !Ref EnableSplunk
+        SplunkSubscriptionFilterRole: !ImportValue lambda-resources:SplunkSubscriptionFilterRole
+        SplunkDeliveryStreamArn: !ImportValue lambda-resources:SplunkDeliveryStream
+
 Outputs:
   UpdatePrescriptionStatusFunctionName:
     Description: The function name of the UpdatePrescriptionStatus lambda
@@ -378,3 +419,11 @@ Outputs:
       - ShouldDeployCheckPrescriptionStatusUpdate
       - !GetAtt CheckPrescriptionStatusUpdates.Arn
       - ""
+
+  NHSNotifyLambdaFunctionName:
+    Description: The function name of the NHS Notify lambda
+    Value: !Ref NHSNotifyLambda
+
+  NHSNotifyLambdaFunctionArn:
+    Description: The function ARN of the NHS Notify lambda
+    Value: !GetAtt NHSNotifyLambda.Arn

--- a/SAMtemplates/main_template.yaml
+++ b/SAMtemplates/main_template.yaml
@@ -161,3 +161,11 @@ Resources:
         ConvertRequestToFhirFormatFunctionName: !GetAtt Functions.Outputs.ConvertRequestToFhirFormatFunctionName
         DynamoDBUtilizationPercentageThreshold: !Ref DynamoDBUtilizationPercentageThreshold
         EnableAlerts: !Ref EnableAlerts
+
+  Scheduler:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: event_bridge/main.yaml
+      Parameters:
+        StackName: !Ref AWS::StackName
+        NHSNotifyLambdaArn: !GetAtt Functions.Outputs.NHSNotifyLambdaFunctionArn

--- a/SAMtemplates/sqs/main.yaml
+++ b/SAMtemplates/sqs/main.yaml
@@ -1,0 +1,38 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  Scheduler to trigger NHSNotifyLambda every minute
+
+Parameters:
+  StackName:
+    Type: String
+  NHSNotifyLambdaArn:
+    Type: String
+    Description: The ARN of the NHSNotifyLambda function
+
+Resources:
+  NHSNotifyScheduler:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: !Sub "${StackName}-NHSNotifySchedulerRule"
+      ScheduleExpression: "rate(1 minute)"
+      State: ENABLED
+      Targets:
+        - Arn: !Ref NHSNotifyLambdaArn
+          Id: "NHSNotifyLambdaTarget"
+
+  NHSNotifyLambdaInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref NHSNotifyLambdaArn
+      Action: "lambda:InvokeFunction"
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt NHSNotifyScheduler.Arn
+
+Outputs:
+  SchedulerRuleName:
+    Description: Name of the scheduler rule triggering NHSNotifyLambda
+    Value: !Ref NHSNotifyScheduler
+  SchedulerRuleArn:
+    Description: ARN of the scheduler rule triggering NHSNotifyLambda
+    Value: !GetAtt NHSNotifyScheduler.Arn

--- a/SAMtemplates/tables/main.yaml
+++ b/SAMtemplates/tables/main.yaml
@@ -428,7 +428,7 @@ Resources:
       AttributeDefinitions:
         - AttributeName: PrescriptionID
           AttributeType: S
-        - AttributeName: NhsNumber
+        - AttributeName: NHSNumber
           AttributeType: S
       KeySchema:
         - AttributeName: PrescriptionID
@@ -438,9 +438,9 @@ Resources:
         - PROVISIONED
         - PAY_PER_REQUEST
       GlobalSecondaryIndexes:
-        - IndexName: NotificationNhsNumberIndex
+        - IndexName: NotificationNHSNumberIndex
           KeySchema:
-            - AttributeName: NhsNumber
+            - AttributeName: NHSNumber
               KeyType: HASH
           Projection:
             ProjectionType: ALL
@@ -525,25 +525,25 @@ Resources:
           PredefinedMetricType: DynamoDBReadCapacityUtilization
 
   # Auto scaling for the global secondary index, NHS number and PrescriptionID
-  NotificationNhsNumberIndexScalingWriteTarget:
+  NotificationNHSNumberIndexScalingWriteTarget:
     Type: AWS::ApplicationAutoScaling::ScalableTarget
     DependsOn: PrescriptionNotificationStateTable
     Condition: EnableDynamoDBAutoScalingCondition
     Properties:
       MinCapacity: !Ref MinWritePrescriptionNotificationStateCapacity
       MaxCapacity: !Ref MaxWritePrescriptionNotificationStateCapacity
-      ResourceId: !Sub table/${PrescriptionNotificationStateTable}/index/NotificationNhsNumberIndex
+      ResourceId: !Sub table/${PrescriptionNotificationStateTable}/index/NotificationNHSNumberIndex
       RoleARN: !GetAtt DynamoDbScalingRole.Arn
       ScalableDimension: "dynamodb:index:WriteCapacityUnits"
       ServiceNamespace: dynamodb
 
-  NotificationNhsNumberIndexScalingWritePolicy:
+  NotificationNHSNumberIndexScalingWritePolicy:
     Type: AWS::ApplicationAutoScaling::ScalingPolicy
     Condition: EnableDynamoDBAutoScalingCondition
     Properties:
-      PolicyName: NotificationNhsNumberIndexScalingWritePolicy
+      PolicyName: NotificationNHSNumberIndexScalingWritePolicy
       PolicyType: TargetTrackingScaling
-      ScalingTargetId: !Ref NotificationNhsNumberIndexScalingWriteTarget
+      ScalingTargetId: !Ref NotificationNHSNumberIndexScalingWriteTarget
       TargetTrackingScalingPolicyConfiguration:
         TargetValue: 50
         ScaleInCooldown: 600
@@ -551,25 +551,25 @@ Resources:
         PredefinedMetricSpecification:
           PredefinedMetricType: DynamoDBWriteCapacityUtilization
 
-  NotificationNhsNumberIndexScalingReadTarget:
+  NotificationNHSNumberIndexScalingReadTarget:
     Type: AWS::ApplicationAutoScaling::ScalableTarget
     DependsOn: PrescriptionNotificationStateTable
     Condition: EnableDynamoDBAutoScalingCondition
     Properties:
       MinCapacity: 1
       MaxCapacity: 100
-      ResourceId: !Sub table/${PrescriptionNotificationStateTable}/index/NotificationNhsNumberIndex
+      ResourceId: !Sub table/${PrescriptionNotificationStateTable}/index/NotificationNHSNumberIndex
       RoleARN: !GetAtt DynamoDbScalingRole.Arn
       ScalableDimension: "dynamodb:index:ReadCapacityUnits"
       ServiceNamespace: dynamodb
 
-  NotificationNhsNumberIndexScalingReadPolicy:
+  NotificationNHSNumberIndexScalingReadPolicy:
     Type: AWS::ApplicationAutoScaling::ScalingPolicy
     Condition: EnableDynamoDBAutoScalingCondition
     Properties:
-      PolicyName: NotificationNhsNumberIndexReadScalingPolicy
+      PolicyName: NotificationNHSNumberIndexReadScalingPolicy
       PolicyType: TargetTrackingScaling
-      ScalingTargetId: !Ref NotificationNhsNumberIndexScalingReadTarget
+      ScalingTargetId: !Ref NotificationNHSNumberIndexScalingReadTarget
       TargetTrackingScalingPolicyConfiguration:
         TargetValue: 70
         ScaleInCooldown: 60

--- a/SAMtemplates/tables/main.yaml
+++ b/SAMtemplates/tables/main.yaml
@@ -19,12 +19,72 @@ Parameters:
     Type: Number
     Default: 600
 
+  MinWritePrescriptionNotificationStateCapacity:
+    Type: Number
+    Default: 50
+
+  MaxWritePrescriptionNotificationStateCapacity:
+    Type: Number
+    Default: 600
+
 Conditions:
   EnableDynamoDBAutoScalingCondition: !Equals
     - true
     - !Ref EnableDynamoDBAutoScaling
 
 Resources:
+
+#---------------------#
+#    Common things    #
+#---------------------#
+
+  DynamoDbScalingRolePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument: !Sub |
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "dynamodb:DescribeTable",
+                        "dynamodb:UpdateTable"
+                    ],
+                    "Resource": "${PrescriptionStatusUpdatesTable.Arn}"
+                },
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "cloudwatch:PutMetricAlarm",
+                        "cloudwatch:DescribeAlarms",
+                        "cloudwatch:DeleteAlarms"
+                    ],
+                    "Resource": "*"
+                }
+            ]
+        }
+
+  DynamoDbScalingRole:
+    Condition: EnableDynamoDBAutoScalingCondition
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              { "Service": ["dynamodb.application-autoscaling.amazonaws.com"] }
+            Action: ["sts:AssumeRole"]
+      Path: "/"
+      ManagedPolicyArns:
+        - !Ref DynamoDbScalingRolePolicy
+
+
+#-----------------------------------------#
+#    Prescription Status Updates Table    #
+#-----------------------------------------#
+
   PrescriptionStatusUpdatesKMSKey:
     Type: AWS::KMS::Key
     Properties:
@@ -149,48 +209,6 @@ Resources:
         StackName: !Ref StackName
         TableName: !Ref PrescriptionStatusUpdatesTable
         TableArn: !GetAtt PrescriptionStatusUpdatesTable.Arn
-
-  DynamoDbScalingRolePolicy:
-    Type: AWS::IAM::ManagedPolicy
-    Properties:
-      PolicyDocument: !Sub |
-        {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Effect": "Allow",
-                    "Action": [
-                        "dynamodb:DescribeTable",
-                        "dynamodb:UpdateTable"
-                    ],
-                    "Resource": "${PrescriptionStatusUpdatesTable.Arn}"
-                },
-                {
-                    "Effect": "Allow",
-                    "Action": [
-                        "cloudwatch:PutMetricAlarm",
-                        "cloudwatch:DescribeAlarms",
-                        "cloudwatch:DeleteAlarms"
-                    ],
-                    "Resource": "*"
-                }
-            ]
-        }
-
-  DynamoDbScalingRole:
-    Condition: EnableDynamoDBAutoScalingCondition
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Principal:
-              { "Service": ["dynamodb.application-autoscaling.amazonaws.com"] }
-            Action: ["sts:AssumeRole"]
-      Path: "/"
-      ManagedPolicyArns:
-        - !Ref DynamoDbScalingRolePolicy
 
   PrescriptionStatusUpdatesTableWriteScalingTarget:
     Type: AWS::ApplicationAutoScaling::ScalableTarget
@@ -348,6 +366,217 @@ Resources:
         PredefinedMetricSpecification:
           PredefinedMetricType: DynamoDBReadCapacityUtilization
 
+
+#--------------------------------#
+#    Notification State Table    #
+#--------------------------------#
+
+  PrescriptionNotificationStateKMSKey:
+    Type: AWS::KMS::Key
+    Properties:
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Id: key-s3
+        Statement:
+          - Sid: Enable IAM User Permissions
+            Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action:
+              - kms:*
+            Resource: "*"
+          - Sid: Enable read only decrypt
+            Effect: Allow
+            Principal:
+              AWS: "*"
+            Action:
+              - kms:DescribeKey
+              - kms:Decrypt
+            Resource: "*"
+            Condition:
+              ArnLike:
+                aws:PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/${AWS::Region}/AWSReservedSSO_ReadOnly*"
+
+  PrescriptionNotificationStateKMSKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub alias/${StackName}-PrescriptionNotificationStateKMSKeyAlias
+      TargetKeyId: !Ref PrescriptionNotificationStateKMSKey
+
+  UsePrescriptionNotificationStateKMSKeyPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - kms:DescribeKey
+              - kms:GenerateDataKey*
+              - kms:Encrypt
+              - kms:ReEncrypt*
+              - kms:Decrypt
+            Resource: !GetAtt PrescriptionStatusUpdatesKMSKey.Arn
+
+  PrescriptionNotificationStateTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub ${StackName}-PrescriptionNotificationState
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      AttributeDefinitions:
+        - AttributeName: PrescriptionID
+          AttributeType: S
+        - AttributeName: NhsNumber
+          AttributeType: S
+      KeySchema:
+        - AttributeName: PrescriptionID
+          KeyType: HASH
+      BillingMode: !If
+        - EnableDynamoDBAutoScalingCondition
+        - PROVISIONED
+        - PAY_PER_REQUEST
+      GlobalSecondaryIndexes:
+        - IndexName: NotificationNhsNumberIndex
+          KeySchema:
+            - AttributeName: NhsNumber
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
+          ProvisionedThroughput: !If
+            - EnableDynamoDBAutoScalingCondition
+            - ReadCapacityUnits: 1
+              WriteCapacityUnits: !Ref MinWritePrescriptionNotificationStateCapacity
+            - !Ref "AWS::NoValue"
+      ProvisionedThroughput: !If
+        - EnableDynamoDBAutoScalingCondition
+        - ReadCapacityUnits: 1
+          WriteCapacityUnits: !Ref MinWritePrescriptionNotificationStateCapacity
+        - !Ref "AWS::NoValue"
+      SSESpecification:
+        KMSMasterKeyId: !Ref PrescriptionNotificationStateKMSKey
+        SSEEnabled: true
+        SSEType: KMS
+      TimeToLiveSpecification:
+        AttributeName: ExpiryTime
+        Enabled: true
+
+  PrescriptionNotificationStateResources:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: dynamodb_resources.yaml
+      Parameters:
+        StackName: !Ref StackName
+        TableName: !Ref PrescriptionNotificationStateTable
+        TableArn: !GetAtt PrescriptionNotificationStateTable.Arn
+
+  # Auto scaling for the table
+  PrescriptionNotificationStateTableWriteScalingTarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    DependsOn: PrescriptionNotificationStateTable
+    Condition: EnableDynamoDBAutoScalingCondition
+    Properties:
+      MinCapacity: !Ref MinWritePrescriptionNotificationStateCapacity
+      MaxCapacity: !Ref MaxWritePrescriptionNotificationStateCapacity
+      ResourceId: !Sub table/${PrescriptionNotificationStateTable}
+      RoleARN: !GetAtt DynamoDbScalingRole.Arn
+      ScalableDimension: "dynamodb:table:WriteCapacityUnits"
+      ServiceNamespace: dynamodb
+
+  PrescriptionNotificationStateTableWriteScalingPolicy:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Condition: EnableDynamoDBAutoScalingCondition
+    Properties:
+      PolicyName: PrescriptionNotificationStateTableWriteScalingPolicy
+      PolicyType: TargetTrackingScaling
+      ScalingTargetId: !Ref PrescriptionNotificationStateTableWriteScalingTarget
+      TargetTrackingScalingPolicyConfiguration:
+        TargetValue: 50
+        ScaleInCooldown: 600
+        ScaleOutCooldown: 0
+        PredefinedMetricSpecification:
+          PredefinedMetricType: DynamoDBWriteCapacityUtilization
+
+  PrescriptionNotificationStateTableReadScalingTarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    DependsOn: PrescriptionNotificationStateTable
+    Condition: EnableDynamoDBAutoScalingCondition
+    Properties:
+      MinCapacity: 1
+      MaxCapacity: 100
+      ResourceId: !Sub table/${PrescriptionNotificationStateTable}
+      RoleARN: !GetAtt DynamoDbScalingRole.Arn
+      ScalableDimension: "dynamodb:table:ReadCapacityUnits"
+      ServiceNamespace: dynamodb
+
+  PrescriptionNotificationStateTableReadScalingPolicy:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Condition: EnableDynamoDBAutoScalingCondition
+    Properties:
+      PolicyName: PrescriptionNotificationStateTableReadScalingPolicy
+      PolicyType: TargetTrackingScaling
+      ScalingTargetId: !Ref PrescriptionNotificationStateTableReadScalingTarget
+      TargetTrackingScalingPolicyConfiguration:
+        TargetValue: 70
+        ScaleInCooldown: 60
+        ScaleOutCooldown: 60
+        PredefinedMetricSpecification:
+          PredefinedMetricType: DynamoDBReadCapacityUtilization
+
+  # Auto scaling for the global secondary index, NHS number and PrescriptionID
+  NotificationNhsNumberIndexScalingWriteTarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    DependsOn: PrescriptionNotificationStateTable
+    Condition: EnableDynamoDBAutoScalingCondition
+    Properties:
+      MinCapacity: !Ref MinWritePrescriptionNotificationStateCapacity
+      MaxCapacity: !Ref MaxWritePrescriptionNotificationStateCapacity
+      ResourceId: !Sub table/${PrescriptionNotificationStateTable}/index/NotificationNhsNumberIndex
+      RoleARN: !GetAtt DynamoDbScalingRole.Arn
+      ScalableDimension: "dynamodb:index:WriteCapacityUnits"
+      ServiceNamespace: dynamodb
+
+  NotificationNhsNumberIndexScalingWritePolicy:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Condition: EnableDynamoDBAutoScalingCondition
+    Properties:
+      PolicyName: NotificationNhsNumberIndexScalingWritePolicy
+      PolicyType: TargetTrackingScaling
+      ScalingTargetId: !Ref NotificationNhsNumberIndexScalingWriteTarget
+      TargetTrackingScalingPolicyConfiguration:
+        TargetValue: 50
+        ScaleInCooldown: 600
+        ScaleOutCooldown: 0
+        PredefinedMetricSpecification:
+          PredefinedMetricType: DynamoDBWriteCapacityUtilization
+
+  NotificationNhsNumberIndexScalingReadTarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    DependsOn: PrescriptionNotificationStateTable
+    Condition: EnableDynamoDBAutoScalingCondition
+    Properties:
+      MinCapacity: 1
+      MaxCapacity: 100
+      ResourceId: !Sub table/${PrescriptionNotificationStateTable}/index/NotificationNhsNumberIndex
+      RoleARN: !GetAtt DynamoDbScalingRole.Arn
+      ScalableDimension: "dynamodb:index:ReadCapacityUnits"
+      ServiceNamespace: dynamodb
+
+  NotificationNhsNumberIndexScalingReadPolicy:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Condition: EnableDynamoDBAutoScalingCondition
+    Properties:
+      PolicyName: NotificationNhsNumberIndexReadScalingPolicy
+      PolicyType: TargetTrackingScaling
+      ScalingTargetId: !Ref NotificationNhsNumberIndexScalingReadTarget
+      TargetTrackingScalingPolicyConfiguration:
+        TargetValue: 70
+        ScaleInCooldown: 60
+        ScaleOutCooldown: 60
+        PredefinedMetricSpecification:
+          PredefinedMetricType: DynamoDBReadCapacityUtilization
+
 Outputs:
   PrescriptionStatusUpdatesTableName:
     Description: PrescriptionStatusUpdates table name
@@ -356,7 +585,15 @@ Outputs:
   PrescriptionStatusUpdatesTableArn:
     Description: PrescriptionStatusUpdates table arn
     Value: !GetAtt PrescriptionStatusUpdatesTable.Arn
+    
+  PrescriptionNotificationStateTableName:
+    Description: "PrescriptionNotificationState table name"
+    Value: !Ref PrescriptionNotificationStateTable
 
+  PrescriptionNotificationStateTableArn:
+    Description: "PrescriptionNotificationState table ARN"
+    Value: !GetAtt PrescriptionNotificationStateTable.Arn
+    
   UsePrescriptionStatusUpdatesKMSKeyPolicyArn:
     Description: Use kms key policy arn
     Value: !GetAtt UsePrescriptionStatusUpdatesKMSKeyPolicy.PolicyArn

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "packages/capabilityStatement",
         "packages/cpsuLambda",
         "packages/checkPrescriptionStatusUpdates",
+        "packages/nhsNotifyLambda",
         "packages/common/testing",
         "packages/common/middyErrorHandler"
       ],
@@ -10657,6 +10658,10 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nhsNotifyLambda": {
+      "resolved": "packages/nhsNotifyLambda",
+      "link": true
+    },
     "node_modules/nise": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
@@ -17430,6 +17435,23 @@
         "@middy/validator": "^6.1.6",
         "@PrescriptionStatusUpdate_common/middyErrorHandler": "^1.0.0",
         "json-schema-to-ts": "^3.1.1"
+      }
+    },
+    "packages/nhsNotifyLambda": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@aws-lambda-powertools/commons": "^2.17.0",
+        "@aws-lambda-powertools/logger": "^2.18.0",
+        "@aws-lambda-powertools/parameters": "^2.18.0",
+        "@middy/core": "^6.1.6",
+        "@middy/input-output-logger": "^6.1.6",
+        "@nhs/fhir-middy-error-handler": "^2.1.28",
+        "axios": "^1.8.4"
+      },
+      "devDependencies": {
+        "@PrescriptionStatusUpdate_common/testing": "^1.0.0",
+        "axios-mock-adapter": "^2.1.0"
       }
     },
     "packages/sandbox": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "packages/capabilityStatement",
     "packages/cpsuLambda",
     "packages/checkPrescriptionStatusUpdates",
+    "packages/nhsNotifyLambda",
     "packages/common/testing",
     "packages/common/middyErrorHandler"
   ],

--- a/packages/nhsNotifyLambda/.vscode/launch.json
+++ b/packages/nhsNotifyLambda/.vscode/launch.json
@@ -1,0 +1,35 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+      {
+          "type": "node",
+          "name": "vscode-jest-tests.v2",
+          "request": "launch",
+          "args": [
+              "--runInBand",
+              "--watchAll=false",
+              "--testNamePattern",
+              "${jest.testNamePattern}",
+              "--runTestsByPath",
+              "${jest.testFile}",
+              "--config",
+              "${workspaceFolder}/jest.debug.config.ts"
+          ],
+          "cwd": "${workspaceFolder}",
+          "console": "integratedTerminal",
+          "internalConsoleOptions": "neverOpen",
+          "disableOptimisticBPs": true,
+          "program": "${workspaceFolder}/../../node_modules/.bin/jest",
+          "windows": {
+              "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+          },
+          "env": {
+              "POWERTOOLS_DEV": true,
+              "NODE_OPTIONS": "--experimental-vm-modules"
+          }
+      }
+  ]
+}

--- a/packages/nhsNotifyLambda/.vscode/settings.json
+++ b/packages/nhsNotifyLambda/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "jest.jestCommandLine": "/workspaces/eps-prescription-status-update-api/node_modules/.bin/jest --no-cache",
+  "jest.nodeEnv": {
+    "POWERTOOLS_DEV": true,
+    "NODE_OPTIONS": "--experimental-vm-modules"
+  }
+}

--- a/packages/nhsNotifyLambda/jest.config.ts
+++ b/packages/nhsNotifyLambda/jest.config.ts
@@ -1,0 +1,9 @@
+import defaultConfig from "../../jest.default.config"
+import type {JestConfigWithTsJest} from "ts-jest"
+
+const jestConfig: JestConfigWithTsJest = {
+  ...defaultConfig,
+  "rootDir": "./"
+}
+
+export default jestConfig

--- a/packages/nhsNotifyLambda/jest.debug.config.ts
+++ b/packages/nhsNotifyLambda/jest.debug.config.ts
@@ -1,0 +1,9 @@
+import config from "./jest.config"
+import type {JestConfigWithTsJest} from "ts-jest"
+
+const debugConfig: JestConfigWithTsJest = {
+  ...config,
+  "preset": "ts-jest"
+}
+
+export default debugConfig

--- a/packages/nhsNotifyLambda/package.json
+++ b/packages/nhsNotifyLambda/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "nhsNotifyLambda",
+  "version": "1.0.0",
+  "description": "A lambda that processes notification requests off SQS",
+  "main": "nhsNotifyLambda.js",
+  "author": "NHS Digital",
+  "license": "MIT",
+  "scripts": {
+    "unit": "POWERTOOLS_DEV=true NODE_OPTIONS=--experimental-vm-modules jest --no-cache --coverage",
+    "lint": "eslint  --max-warnings 0 --fix --config ../../eslint.config.mjs .",
+    "compile": "tsc",
+    "test": "npm run compile && npm run unit",
+    "check-licenses": "license-checker --failOn GPL --failOn LGPL --start ../.."
+  },
+  "dependencies": {
+    "@aws-lambda-powertools/commons": "^2.17.0",
+    "@aws-lambda-powertools/logger": "^2.18.0",
+    "@aws-lambda-powertools/parameters": "^2.18.0",
+    "@middy/core": "^6.1.6",
+    "@middy/input-output-logger": "^6.1.6",
+    "@nhs/fhir-middy-error-handler": "^2.1.28",
+    "axios": "^1.8.4"
+  },
+  "devDependencies": {
+    "@PrescriptionStatusUpdate_common/testing": "^1.0.0",
+    "axios-mock-adapter": "^2.1.0"
+  }
+}

--- a/packages/nhsNotifyLambda/src/nhsNotifyLambda.ts
+++ b/packages/nhsNotifyLambda/src/nhsNotifyLambda.ts
@@ -1,4 +1,4 @@
-import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda"
+import {EventBridgeEvent} from "aws-lambda"
 import {Logger} from "@aws-lambda-powertools/logger"
 import {injectLambdaContext} from "@aws-lambda-powertools/logger/middleware"
 import middy from "@middy/core"
@@ -7,37 +7,23 @@ import errorHandler from "@nhs/fhir-middy-error-handler"
 
 const logger = new Logger({serviceName: "nhsNotify"})
 
-/* eslint-disable  max-len */
-
 /**
+ * Handler for the scheduled trigger.
  *
- * Event doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
- * @param {Object} _event - API Gateway Lambda Proxy Input Format
- *
- * Return doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html
- * @returns {Object} object - API Gateway Lambda Proxy Output Format
- *
+ * @param event - The CloudWatch EventBridge scheduled event payload.
  */
+const lambdaHandler = async (event: EventBridgeEvent<never, string>): Promise<void> => {
+  // FIXME: use proper typing for the above argument.
+  // EventBridge jsonifies the details so the second on is a string
 
-const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
-  logger.appendKeys({
-    "x-request-id": event.headers["x-request-id"],
-    "x-correlation-id": event.headers["x-correlation-id"],
-    "apigw-request-id": event.requestContext.requestId
-  })
+  logger.info("NHS Notify lambda triggered by scheduler", {event})
 
-  logger.info("Notify lambda called")
-
-  const nhsNotifyResponseBody = {message: "OK"}
-
-  return {
-    statusCode: 200,
-    body: JSON.stringify(nhsNotifyResponseBody),
-    headers: {
-      "Content-Type": "application/health+json",
-      "Cache-Control": "no-cache"
-    }
-  }
+  // TODO: Notifications logic will be done here.
+  // - pick off SQS messages
+  // - query PrescriptionNotificationState
+  // - process prescriptions, build NHS notify payload
+  // - Make NHS notify request
+  // Don't forget to make appropriate logs.
 }
 
 export const handler = middy(lambdaHandler)

--- a/packages/nhsNotifyLambda/src/nhsNotifyLambda.ts
+++ b/packages/nhsNotifyLambda/src/nhsNotifyLambda.ts
@@ -1,0 +1,52 @@
+import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda"
+import {Logger} from "@aws-lambda-powertools/logger"
+import {injectLambdaContext} from "@aws-lambda-powertools/logger/middleware"
+import middy from "@middy/core"
+import inputOutputLogger from "@middy/input-output-logger"
+import errorHandler from "@nhs/fhir-middy-error-handler"
+
+const logger = new Logger({serviceName: "nhsNotify"})
+
+/* eslint-disable  max-len */
+
+/**
+ *
+ * Event doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
+ * @param {Object} _event - API Gateway Lambda Proxy Input Format
+ *
+ * Return doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html
+ * @returns {Object} object - API Gateway Lambda Proxy Output Format
+ *
+ */
+
+const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  logger.appendKeys({
+    "x-request-id": event.headers["x-request-id"],
+    "x-correlation-id": event.headers["x-correlation-id"],
+    "apigw-request-id": event.requestContext.requestId
+  })
+
+  logger.info("Notify lambda called")
+
+  const nhsNotifyResponseBody = {message: "OK"}
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify(nhsNotifyResponseBody),
+    headers: {
+      "Content-Type": "application/health+json",
+      "Cache-Control": "no-cache"
+    }
+  }
+}
+
+export const handler = middy(lambdaHandler)
+  .use(injectLambdaContext(logger, {clearState: true}))
+  .use(
+    inputOutputLogger({
+      logger: (request) => {
+        logger.info(request)
+      }
+    })
+  )
+  .use(errorHandler({logger: logger}))

--- a/packages/nhsNotifyLambda/tests/test-handler.test.ts
+++ b/packages/nhsNotifyLambda/tests/test-handler.test.ts
@@ -1,0 +1,30 @@
+import {expect, describe, it} from "@jest/globals"
+
+import {APIGatewayProxyResult} from "aws-lambda"
+
+import axios from "axios"
+import MockAdapter from "axios-mock-adapter"
+
+import {handler} from "../src/nhsNotifyLambda"
+import {mockAPIGatewayProxyEvent, mockContext} from "@PrescriptionStatusUpdate_common/testing"
+
+const mock = new MockAdapter(axios)
+
+describe("Unit test for NHS Notify lambda handler", function () {
+  let originalEnv: {[key: string]: string | undefined} = process.env
+  afterEach(() => {
+    process.env = {...originalEnv}
+    mock.reset()
+  })
+
+  it("Dummy test", async () => {
+    console.error("DUMMY TEST - PASSING ANYWAY")
+
+    const result: APIGatewayProxyResult = (await handler(
+      mockAPIGatewayProxyEvent,
+      mockContext
+    )) as APIGatewayProxyResult
+
+    expect(result.statusCode).toEqual(200)
+  })
+})

--- a/packages/nhsNotifyLambda/tsconfig.json
+++ b/packages/nhsNotifyLambda/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.defaults.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "lib"
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ authors = [
     "Phil Gee <phil.gee@nhs.net>",
     "Adam Brown <adam.brown41@nhs.net>",
     "Jonathan Welch <jonathan.welch1@nhs.net>",
+    "Jim Wild <james.wild6@nhs.net>",
     "Natasa Fragkou <natasa.fragkou@nhs.net>",
     "Jack Spagnoli <jack.spagnoli1@nhs.net>",
     "Tom Smith <tom.smith24@nhs.net>",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,4 +3,14 @@ sonar.projectKey=NHSDigital_eps-prescription-status-update-api
 sonar.host.url=https://sonarcloud.io
 
 sonar.coverage.exclusions=**/*.test.*,**/mock*,**/jest.*.ts,scripts/*,release.config.js
-sonar.javascript.lcov.reportPaths=packages/gsul/coverage/lcov.info,packages/updatePrescriptionStatus/coverage/lcov.info,packages/sandbox/coverage/lcov.info,packages/specification/coverage/lcov.info,packages/statusLambda/coverage/lcov.info,packages/capabilityStatement/coverage/lcov.info,packages/cpsuLambda/coverage/lcov.info,packages/checkPrescriptionStatusUpdates/coverage/lcov.info,packages/common/middyErrorHandler/coverage/lcov.info
+sonar.javascript.lcov.reportPaths=\
+    packages/gsul/coverage/lcov.info, \
+    packages/updatePrescriptionStatus/coverage/lcov.info, \
+    packages/sandbox/coverage/lcov.info, \
+    packages/specification/coverage/lcov.info, \
+    packages/statusLambda/coverage/lcov.info, \
+    packages/capabilityStatement/coverage/lcov.info, \
+    packages/cpsuLambda/coverage/lcov.info, \
+    packages/checkPrescriptionStatusUpdates/coverage/lcov.info, \
+    packages/nhsNotifyLambda/coverage/lcov.info, \
+    packages/common/middyErrorHandler/coverage/lcov.info

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -12,6 +12,7 @@
     {"path": "packages/statusLambda"},
     {"path": "packages/capabilityStatement"},
     {"path": "packages/cpsuLambda"},
-    {"path": "packages/checkPrescriptionStatusUpdates"}
+    {"path": "packages/checkPrescriptionStatusUpdates"},
+    {"path": "packages/nhsNotifyLambda"}
   ]
 }


### PR DESCRIPTION
## Summary

- :sparkles: New Feature

### Details

This PR is to add the various components needed for the NHS notify integration to the PSU.

There are four new things to deploy:
- EventBridge scheduler
- Lambda function to handle the processing, triggered by the scheduler
- SQS (eventually to be populated by the existing PSU function)
- Notifications state Dynamo database

Initially, the only requirement is that the lambda function is executed every minute. The PSU will not push anything to SQS yet. The lambda will only log that it has been run.