### PR TITLE
Fix: [AEA-0000] - Fix scheduler name

### DIFF
--- a/SAMtemplates/functions/main.yaml
+++ b/SAMtemplates/functions/main.yaml
@@ -386,7 +386,7 @@ Resources:
         ScheduleEvent:
           Type: ScheduleV2
           Properties:
-            Name: !Sub ${StackName}-NHSNotifySchedule
+            Name: !Sub ${StackName}-NotifySchedule
             ScheduleExpression: "rate(1 minute)"
             RoleArn: !GetAtt NotifyProcessorScheduleEventRole.Arn
     Metadata:


### PR DESCRIPTION
## Summary

- Routine Change

### Details

A scheduler name was not updated, which causes a conflict when updating an existing stack. This should fix that.