### PR TITLE
New: [AEA-5296] - Log message for ITOC monitoring

### DIFF
--- a/packages/nhsNotifyLambda/src/nhsNotifyLambda.ts
+++ b/packages/nhsNotifyLambda/src/nhsNotifyLambda.ts
@@ -12,6 +12,7 @@ import {
   addPrescriptionMessagesToNotificationStateStore,
   checkCooldownForUpdate,
   removeSQSMessages,
+  reportQueueStatus,
   drainQueue,
   makeBatchNotifyRequest,
   NotifyDataItemMessage
@@ -108,6 +109,7 @@ export const lambdaHandler = async (
   logger.info("NHS Notify lambda triggered by scheduler", {event})
   logger.info("Routing Plan ID:", {routingId})
 
+  await reportQueueStatus(logger)
   await drainAndProcess(routingId)
 }
 


### PR DESCRIPTION
## Summary

- :sparkles: New Feature

### Details

Log the queue attributes at the start of the processor run. 
- timestamp
- Number of messages on queue
- Number of invisible messages
- Number of delayed message
There should always be 0 delayed messages.