### PR TITLE
Fix; [AEA-0000] - Update the SSM policy to be more restrictive

### DIFF
--- a/SAMtemplates/functions/lambda_resources.yaml
+++ b/SAMtemplates/functions/lambda_resources.yaml
@@ -106,20 +106,6 @@ Resources:
               - !GetAtt LambdaLogGroup.Arn
               - !Sub ${LambdaLogGroup.Arn}:log-stream:*
 
-  SSMGetParameterPolicy:
-    Type: AWS::IAM::ManagedPolicy
-    Properties:
-      Description: "Allows reading SSM parameters"
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Action:
-              - ssm:GetParameter
-              - ssm:GetParameters
-            Resource:
-              - "*"
-
   LambdaLogGroup:
     Type: AWS::Logs::LogGroup
     Metadata:

--- a/SAMtemplates/functions/main.yaml
+++ b/SAMtemplates/functions/main.yaml
@@ -137,6 +137,7 @@ Resources:
             - Fn::ImportValue: !Sub ${StackName}-UseNotificationSQSQueueKMSKeyPolicyArn
             - Fn::ImportValue: !Sub ${StackName}-WriteNHSNotifyPrescriptionsSQSQueuePolicyArn
             - Fn::ImportValue: !Sub ${StackName}-GetSQSSaltSecretPolicy
+            - Fn::ImportValue: !Sub ${StackName}:parameters:GetNotificationsParameterPolicyArn
         LogRetentionInDays: !Ref LogRetentionInDays
         CloudWatchKMSKeyId: !ImportValue account-resources:CloudwatchLogsKmsKeyArn
         EnableSplunk: !Ref EnableSplunk
@@ -450,6 +451,7 @@ Resources:
             - Fn::ImportValue: !Sub ${StackName}:tables:${PrescriptionNotificationStatesTableName}:TableReadPolicyArn
             - Fn::ImportValue: !Sub ${StackName}:tables:${PrescriptionNotificationStatesTableName}:TableWritePolicyArn
             - Fn::ImportValue: !Sub ${StackName}:tables:UsePrescriptionNotificationStatesKMSKeyPolicyArn
+            - Fn::ImportValue: !Sub ${StackName}:parameters:GetNotificationsParameterPolicyArn
 
   NHSNotifyUpdateCallback:
     Type: AWS::Serverless::Function

--- a/SAMtemplates/parameters/main.yaml
+++ b/SAMtemplates/parameters/main.yaml
@@ -99,6 +99,27 @@ Resources:
       Type: String
       Value: "true"
 
+  GetNotificationsParameterPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: "Allows reading SSM parameters"
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - ssm:GetParameter
+              - ssm:GetParameters
+            Resource:
+              - !GetAtt EnabledSiteODSCodesParameter.Arn
+              - !GetAtt EnabledSystemsParameter.Arn
+              - !GetAtt BlockedSiteODSCodesParameter.Arn
+              - !GetAtt NotifyRoutingPlanIDParameter.Arn
+              - !GetAtt NotifyAPIBaseURLParameter.Arn
+              - !GetAtt EnableNotificationExternalLink.Arn
+              - !GetAtt EnableNotificationsInternal.Arn
+
+
 Outputs:
   EnabledSiteODSCodesParameterName:
     Description: "Name of the SSM parameter holding enabled site ODS codes"
@@ -141,3 +162,9 @@ Outputs:
     Value: !Ref EnableNotificationsInternal
     Export:
       Name: !Sub ${StackName}-EnableNotificationsInternalName
+
+  GetNotificationsParameterPolicyArn:
+    Description: Use kms key policy arn
+    Value: !GetAtt GetNotificationsParameterPolicy.PolicyArn
+    Export:
+      Name: !Sub ${StackName}:tables:GetNotificationsParameterPolicyArn


### PR DESCRIPTION
## Summary

- Routine Change

### Details

This replaces the blanket "allow access" policy for SSM parameters, with a scoped policy that only allows access to the notifications ones needed.