### PR TITLE
Update: [AEA-5562] - Upload new notification state table

### DIFF
--- a/SAMtemplates/tables/main.yaml
+++ b/SAMtemplates/tables/main.yaml
@@ -470,7 +470,7 @@ Resources:
   PrescriptionNotificationStatesTableV1:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Sub ${StackName}-PrescriptionNotificationStates
+      TableName: !Sub ${StackName}-PrescriptionNotificationStatesV1
       PointInTimeRecoverySpecification:
         PointInTimeRecoveryEnabled: true
       AttributeDefinitions:

--- a/SAMtemplates/tables/main.yaml
+++ b/SAMtemplates/tables/main.yaml
@@ -466,6 +466,72 @@ Resources:
         AttributeName: ExpiryTime
         Enabled: true
 
+
+  PrescriptionNotificationStatesTableV1:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub ${StackName}-PrescriptionNotificationStates
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      AttributeDefinitions:
+        - AttributeName: NHSNumber
+          AttributeType: S
+        - AttributeName: ODSCode
+          AttributeType: S
+        - AttributeName: RequestId # this is the PSU request ID, and is used to identify a single notification's flow
+          AttributeType: S
+        - AttributeName: NotifyMessageID # This is the ID returned by Notify for this notification request. Used for callback lookup
+          AttributeType: S
+
+      GlobalSecondaryIndexes:
+        - IndexName: PatientPharmacyIndex
+          KeySchema:
+            - AttributeName: NHSNumber
+              KeyType: HASH
+            - AttributeName: ODSCode
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+          ProvisionedThroughput: !If
+            - EnableDynamoDBAutoScalingCondition
+            - ReadCapacityUnits: 1
+              WriteCapacityUnits: !Ref MinWritePrescriptionNotificationStatesCapacity
+            - !Ref "AWS::NoValue"
+
+        - IndexName: NotifyMessageIDIndex
+          KeySchema:
+            - AttributeName: NotifyMessageID
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
+          ProvisionedThroughput: !If
+            - EnableDynamoDBAutoScalingCondition
+            - ReadCapacityUnits: 1
+              WriteCapacityUnits: !Ref MinWritePrescriptionNotificationStatesCapacity
+            - !Ref "AWS::NoValue"
+
+      KeySchema:
+        - AttributeName: NHSNumber
+          KeyType: HASH       # Partition key
+        - AttributeName: RequestId
+          KeyType: RANGE      # Sort key
+      BillingMode: !If
+        - EnableDynamoDBAutoScalingCondition
+        - PROVISIONED
+        - PAY_PER_REQUEST
+      ProvisionedThroughput: !If
+        - EnableDynamoDBAutoScalingCondition
+        - ReadCapacityUnits: 1
+          WriteCapacityUnits: !Ref MinWritePrescriptionNotificationStatesCapacity
+        - !Ref "AWS::NoValue"
+      SSESpecification:
+        KMSMasterKeyId: !Ref PrescriptionNotificationStatesKMSKey
+        SSEEnabled: true
+        SSEType: KMS
+      TimeToLiveSpecification:
+        AttributeName: ExpiryTime
+        Enabled: true
+
   PrescriptionNotificationStatesResources:
     Type: AWS::Serverless::Application
     Properties:


### PR DESCRIPTION
## Summary

- Routine Change

### Details

This PR just uploads the new dynamo table for the notification states. Then, #1930 can be deployed without breaking AWS.

The first commit will be in line with the current main branch. Then, I'll push the changes to the table definitions. This should show us that prod won't break.