### PR TITLE
Fix: [AEA-0000] - Make a log about silent running requests being sent, that mirrors the real success log message

### DIFF
--- a/packages/nhsNotifyLambda/src/utils/notify.ts
+++ b/packages/nhsNotifyLambda/src/utils/notify.ts
@@ -108,12 +108,24 @@ export async function makeBatchNotifyRequest(
     logger.info("Not doing real Notify requests. Simply waiting for some time and returning success on all messages")
     await new Promise(f => setTimeout(f, DUMMY_NOTIFY_DELAY_MS))
 
+    const deliveryStatus = "silent running"
+
+    logger.info("Requested notifications OK!", {
+      messageBatchReference,
+      messageReferences: messages.map(e => ({
+        nhsNumber: e.recipient.nhsNumber,
+        messageReference: e.messageReference,
+        psuRequestId: data.find((el) => el.messageReference === e.messageReference)?.PSUDataItem.RequestID
+      })),
+      deliveryStatus
+    })
+
     // Map each input item to a "successful" NotifyDataItemMessage
     return data.map(item => {
       return {
         ...item,
         messageBatchReference,
-        deliveryStatus: "silent running",
+        deliveryStatus,
         notifyMessageId: v4() // Create a dummy UUID
       }
     })


### PR DESCRIPTION
## Summary

- Routine Change

### Details

To count the number of notify requests we send, we use this splunk query:
```
index=app_prescriptions_dev earliest=-1d@d latest=@d
(
    (source="aws:loggroup:/aws/lambda/psu-NHSNotifyUpdateCallback"
     OR source="aws:loggroup:/aws/lambda/psu-NotifyProcessor")
    ("Updated notification state" OR "Requested notifications OK!")
)
| spath path=message.newStatus             output=status
| spath path=message.messageReferences{}.nhsNumber  output=nhsNumbers
| eval notifications_requested_count = if(isnull(nhsNumbers),0,mvcount(nhsNumbers))
| stats
    count(eval(status="delivered"))         AS delivered_count
  , count(eval(status="failed"))            AS failed_count
  , sum(notifications_requested_count)      AS notifications_requested_count
| appendcols [
    search index=app_prescriptions_dev earliest=-1d@d latest=@d
        source="aws:loggroup:/aws/lambda/psu-UpdatePrescriptionStatus"
        "Transitioning item status."
    | spath path=message.newStatus output=status
    | regex status="(?i).*ready to collect.*"
    | stats count AS ready_to_collect_psu_count
]
| eval timestamp = strftime(relative_time(now(), "-1d@d"), "%d/%m/%Y")
| table timestamp delivered_count failed_count notifications_requested_count ready_to_collect_psu_count
```

To get the count of notifications requested, it searches for logs containing "Requested notifications OK!" and counts how many NHS numbers are reported in that payload. 

This PR copies the log message from a successful send, into the `silent running` catch, meaning that messages "sent" under silent running may also be counted.