### PR TITLE
New: [AEA-0000] - Add logic to handle the channel status callback updates

### DIFF
--- a/packages/nhsNotifyUpdateCallback/src/lambdaHandler.ts
+++ b/packages/nhsNotifyUpdateCallback/src/lambdaHandler.ts
@@ -9,7 +9,7 @@ import httpHeaderNormalizer from "@middy/http-header-normalizer"
 
 import errorHandler from "@nhs/fhir-middy-error-handler"
 
-import {MessageStatusResponse} from "./types"
+import {CallbackType, CallbackResponse} from "./types"
 import {checkSignature, response, updateNotificationsTable} from "./helpers"
 
 export const logger = new Logger({serviceName: "nhsNotifyUpdateCallback"})
@@ -20,7 +20,6 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
     "apigw-request-id": event.headers["apigw-request-id"],
     "x-request-id": event.headers["x-request-id"]
   })
-  logger.info("Lambda called with this event", {event})
 
   // Require a request ID
   if (!event.headers["x-request-id"]) return response(400, {message: "No x-request-id given"})
@@ -28,11 +27,10 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
   // Check the request signature
   const isErr = await checkSignature(logger, event)
   if (isErr) return isErr
-  logger.info("Signature OK!")
 
   // Parse out the request body
   if (!event.body) return response(400, {message: "No request body given"})
-  let payload: MessageStatusResponse
+  let payload: CallbackResponse
   try {
     payload = JSON.parse(event.body)
   } catch (error) {
@@ -40,15 +38,35 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
     return response(400, {message: "Request body failed to parse"})
   }
 
+  let receivedUnknownCallbackType = false
   payload.data.forEach(m => {
-    logger.info(
-      "Message state updated",
-      {
+    let logPayload = {}
+    if (m.type === CallbackType.message) {
+      logPayload = {
+        callbackType: m.type,
         messageStatus: m.attributes.messageStatus,
         messageReference: m.attributes.messageReference,
         messageId: m.attributes.messageId,
         receivedTimestamp: m.attributes.timestamp
       }
+
+    } else if (m.type === CallbackType.channel) {
+      logPayload = {
+        callbackType: m.type,
+        messageStatus: m.attributes.channelStatus,
+        supplierStatus: m.attributes.supplierStatus ?? "not given",
+        retryCount: m.attributes.retryCount,
+        messageReference: m.attributes.messageReference,
+        messageId: m.attributes.messageId,
+        receivedTimestamp: m.attributes.timestamp
+      }
+    } else {
+      logger.warn("Unknown callback data structure.", {data: m})
+      receivedUnknownCallbackType = true
+    }
+    logger.info(
+      "Message state updated",
+      logPayload
     )
   })
 
@@ -59,11 +77,23 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
     return response(500, {message: "Failed to update the notification state table"})
   }
 
-  // All's well that ends well
-  return {
-    statusCode: 202,
-    body: "OK"
+  if (receivedUnknownCallbackType) {
+    logger.info(
+      "Detected some unknown callback types. Returning 400 despite possible partial success."
+    )
+    return response(
+      400,
+      {
+        message: (
+          "Received an unknown callback data type. expected data[].type"
+          + " to always be either ChannelStatus or MessageStatus"
+        )
+      }
+    )
   }
+
+  // All's well that ends well
+  return response(202, "OK")
 }
 
 export const handler = middy(lambdaHandler)

--- a/packages/nhsNotifyUpdateCallback/tests/utilities.ts
+++ b/packages/nhsNotifyUpdateCallback/tests/utilities.ts
@@ -2,6 +2,7 @@
 
 import {APIGatewayProxyEvent} from "aws-lambda"
 import {
+  CallbackType,
   Channel,
   MessageStatusResource,
   MessageStatusResponse,
@@ -61,7 +62,7 @@ export function generateMockMessageStatusResponse(
   ]
 
   const defaultResource: MessageStatusResource = {
-    type: "MessageStatus",
+    type: CallbackType.message,
     attributes: {
       messageId: "msg-123",
       messageReference: "ref-123",


### PR DESCRIPTION
## Summary

- :sparkles: New Feature

### Details

The Notifications callback lambda needs to be able to handle data from both of these schemas:

https://digital.nhs.uk/developer/api-catalogue/nhs-notify#post-/%3Cclient-provided-message-status-URI%3E
https://digital.nhs.uk/developer/api-catalogue/nhs-notify#post-/%3Cclient-provided-channel-status-URI%3E

The message status is already implemented - this PR adds the channel status update logic