### PR TITLE
Chore: [AEA-0000] - Refactor failure logic for the PSU

### DIFF
--- a/packages/updatePrescriptionStatus/src/updatePrescriptionStatus.ts
+++ b/packages/updatePrescriptionStatus/src/updatePrescriptionStatus.ts
@@ -208,6 +208,7 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
       // We're considering this a bust, and if they send a retry before undoing the table
       // bits then they will get a collision. Delete the newly created records then return the error
       await rollbackDataItems(dataItems, logger)
+      responseEntries = [serverError()]
       return response(500, responseEntries)
     }
   } else {

--- a/packages/updatePrescriptionStatus/src/updatePrescriptionStatus.ts
+++ b/packages/updatePrescriptionStatus/src/updatePrescriptionStatus.ts
@@ -15,9 +15,9 @@ import {Bundle, BundleEntry, Task} from "fhir/r4"
 import {PSUDataItem, PSUDataItemWithPrevious} from "@PrescriptionStatusUpdate_common/commonTypes"
 
 import {transactionBundle, validateEntry} from "./validation/content"
-import {getPreviousItem, persistDataItems} from "./utils/databaseClient"
+import {getPreviousItem, persistDataItems, rollbackDataItems} from "./utils/databaseClient"
 import {jobWithTimeout, hasTimedOut} from "./utils/timeoutUtils"
-import {pushPrescriptionToNotificationSQS, removeSqsMessages} from "./utils/sqsClient"
+import {pushPrescriptionToNotificationSQS} from "./utils/sqsClient"
 import {
   accepted,
   badRequest,
@@ -159,22 +159,6 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
     logger.error("Failed to load parameters from SSM", {err})
   }
 
-  let created_messageIds: Array<string> = []
-  if (enableNotificationsFlag) {
-    try {
-      const requestId = event.headers["x-request-id"] ?? "x-request-id-not-found"
-      created_messageIds = await pushPrescriptionToNotificationSQS(requestId, dataItemsWithPrev, logger)
-    } catch (err) {
-      logger.error("Failed to push prescriptions to the notifications SQS", {err})
-      return response(500, responseEntries)
-    }
-  } else {
-    logger.info(
-      "enableNotifications is not true, skipping the notification request.",
-      {enableNotificationsFlag}
-    )
-  }
-
   try {
     const persistSuccess = persistDataItems(dataItems, logger)
     const persistResponse = await jobWithTimeout(LAMBDA_TIMEOUT_MS, persistSuccess)
@@ -182,15 +166,11 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
     if (hasTimedOut(persistResponse)) {
       responseEntries = [timeoutResponse()]
       logger.error("DynamoDB operation timed out.")
-      // It's okay to just call the function here, since if the enableNotifications
-      //  boolean is False, this function does nothing
-      await removeSqsMessages(logger, created_messageIds)
       return response(504, responseEntries)
     }
 
     if (!persistResponse) {
       responseEntries = [serverError()]
-      await removeSqsMessages(logger, created_messageIds)
       return response(500, responseEntries)
     }
 
@@ -202,11 +182,11 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
       if (testPrescription1Forced201) {
         logger.info("Forcing 201 response for INT test prescription 1")
         responseEntries = createSuccessResponseEntries(requestEntries)
+        // Don't attempt to send notifications for these test prescriptions
         return response(201, responseEntries)
       }
 
       handleTransactionCancelledException(e, responseEntries)
-      await removeSqsMessages(logger, created_messageIds)
       return response(409, responseEntries)
     }
   }
@@ -215,8 +195,26 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
   if (testPrescriptionForcedError) {
     logger.info("Forcing error for INT test prescription")
     responseEntries = [serverError()]
-    await removeSqsMessages(logger, created_messageIds)
     return response(500, responseEntries)
+  }
+
+  // If all the PSU stuff went well, then send the notification requests out
+  if (enableNotificationsFlag) {
+    try {
+      const requestId = event.headers["x-request-id"] ?? "x-request-id-not-found"
+      await pushPrescriptionToNotificationSQS(requestId, dataItemsWithPrev, logger)
+    } catch (err) {
+      logger.error("Failed to push prescriptions to the notifications SQS", {err})
+      // We're considering this a bust, and if they send a retry before undoing the table
+      // bits then they will get a collision. Delete the newly created records then return the error
+      await rollbackDataItems(dataItems, logger)
+      return response(500, responseEntries)
+    }
+  } else {
+    logger.info(
+      "enableNotifications is not true, skipping the notification request.",
+      {enableNotificationsFlag}
+    )
   }
 
   return response(201, responseEntries)

--- a/packages/updatePrescriptionStatus/tests/testHandler.test.ts
+++ b/packages/updatePrescriptionStatus/tests/testHandler.test.ts
@@ -39,11 +39,9 @@ import {QueryCommand, TransactionCanceledException, TransactWriteItemsCommand} f
 const {mockSend: dynamoDBMockSend} = mockDynamoDBClient()
 
 const mockPushPrescriptionToNotificationSQS = jest.fn().mockImplementation(async () => Promise.resolve())
-const mockRemoveSqsMessages = jest.fn().mockImplementation(async () => Promise.resolve())
 jest.unstable_mockModule("../src/utils/sqsClient", async () => ({
   __esModule: true,
-  pushPrescriptionToNotificationSQS: mockPushPrescriptionToNotificationSQS,
-  removeSqsMessages: mockRemoveSqsMessages
+  pushPrescriptionToNotificationSQS: mockPushPrescriptionToNotificationSQS
 }))
 
 const mockGetParametersByName = jest.fn(async () => Promise.resolve(
@@ -245,8 +243,6 @@ describe("Integration tests for updatePrescriptionStatus handler", () => {
     const response = await eventHandler
     expect(response.statusCode).toBe(504)
     expect(JSON.parse(response.body)).toEqual(bundleWrap([timeoutResponse()]))
-    expect(mockRemoveSqsMessages).toHaveBeenCalledTimes(1)
-    expect(mockRemoveSqsMessages).toHaveBeenCalledWith(logger, [])
   })
 
   it("when multiple tasks have missing fields, expect 400 status code and messages indicating missing fields", async () => {
@@ -346,8 +342,6 @@ describe("Integration tests for updatePrescriptionStatus handler", () => {
       "Request contains a task id and prescription id identical to a record already in the data store."
     )
     expect(responseBody.entry[1].response.status).not.toEqual("200 OK")
-    expect(mockRemoveSqsMessages).toHaveBeenCalledTimes(1)
-    expect(mockRemoveSqsMessages).toHaveBeenCalledWith(logger, [])
   })
 
   it("when duplicates are introduced without any other entry, expect only 409 status with a message", async () => {
@@ -386,8 +380,6 @@ describe("Integration tests for updatePrescriptionStatus handler", () => {
       "Request contains a task id and prescription id identical to a record already in the data store."
     )
     expect(responseBody.entry[0].response.status).not.toEqual("200 OK")
-    expect(mockRemoveSqsMessages).toHaveBeenCalledTimes(1)
-    expect(mockRemoveSqsMessages).toHaveBeenCalledWith(logger, [])
   })
 
   function itemQueryResult(taskID: string, status: string, businessStatus: string, lastModified: string) {

--- a/packages/updatePrescriptionStatus/tests/testSqsClient.test.ts
+++ b/packages/updatePrescriptionStatus/tests/testSqsClient.test.ts
@@ -8,7 +8,7 @@ import {SpiedFunction} from "jest-mock"
 
 import {Logger} from "@aws-lambda-powertools/logger"
 import {LogItemMessage, LogItemExtraInput} from "@aws-lambda-powertools/logger/lib/cjs/types/Logger"
-import {SendMessageBatchCommand, DeleteMessageBatchCommand} from "@aws-sdk/client-sqs"
+import {SendMessageBatchCommand} from "@aws-sdk/client-sqs"
 
 import {createMockDataItem, mockSQSClient} from "./utils/testUtils"
 
@@ -46,7 +46,6 @@ jest.unstable_mockModule(
 
 const {
   pushPrescriptionToNotificationSQS,
-  removeSqsMessages,
   saltedHash
 } = await import("../src/utils/sqsClient")
 const {checkSiteOrSystemIsNotifyEnabled} = await import("../src/validation/notificationSiteAndSystemFilters")
@@ -235,10 +234,9 @@ describe("Unit tests for getSaltValue", () => {
 
     logger = new Logger({serviceName: "test-service"})
     errorSpy = jest.spyOn(logger, "error")
-    warnSpy = jest.spyOn(logger, "warn")
+    warnSpy = jest.spyOn(logger, "warn");
 
-    // re-import the function after resetModules so mocks are applied
-    ; ({getSaltValue} = await import("../src/utils/sqsClient"))
+    ({getSaltValue} = await import("../src/utils/sqsClient"))
   })
 
   it("returns the fallback salt when SQS_SALT is not configured", async () => {
@@ -382,77 +380,4 @@ describe("Unit tests for checkSiteOrSystemIsNotifyEnabled", () => {
     expect(result).toEqual([])
   })
 
-})
-
-describe("Unit tests for removeSqsMessages", () => {
-  let logger: Logger
-  let infoSpy: SpiedFunction<(input: LogItemMessage, ...extraInput: LogItemExtraInput) => void>
-  let errorSpy: SpiedFunction<(input: LogItemMessage, ...extraInput: LogItemExtraInput) => void>
-
-  beforeEach(async () => {
-    jest.resetModules()
-    jest.clearAllMocks()
-    process.env = {...ORIGINAL_ENV}
-    process.env.NHS_NOTIFY_PRESCRIPTIONS_SQS_QUEUE_URL = "https://queue.url"
-
-    logger = new Logger({serviceName: "test-service"})
-    infoSpy = jest.spyOn(logger, "info")
-    errorSpy = jest.spyOn(logger, "error")
-  })
-
-  it("throws if the SQS URL is not configured", async () => {
-    delete process.env.NHS_NOTIFY_PRESCRIPTIONS_SQS_QUEUE_URL
-    const {removeSqsMessages: tempFunc} = await import("../src/utils/sqsClient")
-    await expect(
-      tempFunc(logger, ["rh1"])
-    ).rejects.toThrow("Notifications SQS URL not configured")
-
-    expect(errorSpy).toHaveBeenCalledWith(
-      "Notifications SQS URL not found in environment variables"
-    )
-    expect(mockSend).not.toHaveBeenCalled()
-  })
-
-  it("does nothing when there are no receipt handles", async () => {
-    await expect(
-      removeSqsMessages(logger, [])
-    ).resolves.toBeUndefined()
-
-    expect(mockSend).not.toHaveBeenCalled()
-  })
-
-  it("deletes messages in batches of 10 and logs successes and failures", async () => {
-    const handles = Array.from({length: 12}, (_, i) => `rh${i}`)
-    const firstResult = {
-      Successful: Array.from({length: 10}, (_, i) => ({Id: i.toString()})),
-      Failed: Array.from({length: 2}, (_, i) => ({Id: (10 + i).toString(), SenderFault: false}))
-    }
-    mockSend
-      .mockImplementationOnce(() => Promise.resolve(firstResult))
-      .mockImplementationOnce(() => Promise.resolve({Successful: [], Failed: []}))
-
-    await removeSqsMessages(logger, handles)
-
-    expect(mockSend).toHaveBeenCalledTimes(2)
-
-    const firstCall = mockSend.mock.calls[0][0]
-    expect(firstCall).toBeInstanceOf(DeleteMessageBatchCommand)
-    if (firstCall instanceof DeleteMessageBatchCommand) {
-      expect(firstCall.input.Entries).toHaveLength(10)
-      expect(infoSpy).toHaveBeenCalledWith(
-        "Successfully removed messages from the SQS queue",
-        {successfulIds: expect.arrayContaining(firstResult.Successful.map(r => r.Id))}
-      )
-      expect(errorSpy).toHaveBeenCalledWith(
-        "Failed to remove some messages from the SQS queue",
-        {failures: firstResult.Failed}
-      )
-    }
-
-    const secondCall = mockSend.mock.calls[1][0]
-    expect(secondCall).toBeInstanceOf(DeleteMessageBatchCommand)
-    if (secondCall instanceof DeleteMessageBatchCommand) {
-      expect(secondCall.input.Entries).toHaveLength(2)
-    }
-  })
 })


### PR DESCRIPTION
## Summary

- Routine Change

### Details

We refactored the PSU handler to:
- Do all the bundle logic
- push to SQS
- Push to database
- return Ok

However, if the database part fails, then we need to delete the SQS messages off the queue. Unfortunately, the function being used to do that only works with the SQS message ID corresponding to a `receive` call, the one we get from *creating* a message does NOT work! 

Log for this happening in int ([specific](https://nhsdigital.splunkcloud.com/en-GB/app/nhse_eps_all_sh_all_viz/search?q=search%20index%3Dapp_prescriptions_int%0Asource%3Daws%3Aloggroup%3A%2Faws%2Flambda%2Fpsu-UpdatePrescriptionStatus%0A%22Failed%20to%20remove%20some%20messages%20from%20the%20SQS%20queue%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=1756249200&latest=1756508400&sid=1756482520.360626_554788E6-EB8B-47F7-A2AF-5D49FC76EE3F) log, [full](https://nhsdigital.splunkcloud.com/en-GB/app/nhse_eps_all_sh_all_viz/search?q=search%20index%3Dapp_prescriptions_int%20source%3Daws%3Aloggroup%3A%2Faws%2Flambda%2Fpsu-UpdatePrescriptionStatus%20%7C%20spath%20%22message.x-request-id%22%20%7C%20search%20%22message.x-request-id%22%3D%2279f0f0bb-8aa4-4760-b980-eca82ab65cff%22&earliest=1756249200&latest=1756508400&display.page.search.mode=verbose&dispatch.sample_ratio=1&sid=1756482570.360634_554788E6-EB8B-47F7-A2AF-5D49FC76EE3F&display.events.type=raw) transaction)

Instead, I've inverted it. The table is now what gets rolled back. I have a check in there to only remove records with matching request IDs.