### PR TITLE
Fix: [AEA-0000] - Correct a silly mistake in notify batch request

### DIFF
--- a/packages/nhsNotifyLambda/src/utils/notify.ts
+++ b/packages/nhsNotifyLambda/src/utils/notify.ts
@@ -98,8 +98,7 @@ export async function handleNotifyRequests(
       messageReference: item.messageReference,
       recipient: {nhsNumber: item.PSUDataItem.PatientNHSNumber},
       originator: {odsCode: item.PSUDataItem.PharmacyODSCode},
-      personalisation: {},
-      PSURequestId: item.PSUDataItem.RequestID
+      personalisation: {}
     }]
   })
 


### PR DESCRIPTION
## Summary

- Routine Change

### Details

I missed a line of code adding a field that should have been taken out. The type checker was happy with it, and I missed it when checking. This removes it.